### PR TITLE
centralized error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/cloudflare/circl v1.3.9 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/internal/tests/R00/ex00.go
+++ b/internal/tests/R00/ex00.go
@@ -10,7 +10,6 @@ import (
 	"github.com/42-Short/shortinette/internal/errors"
 	"github.com/42-Short/shortinette/internal/logger"
 	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
-	"github.com/42-Short/shortinette/pkg/testutils"
 )
 
 func ex00Compile(exercise *Exercise.Exercise) error {
@@ -45,8 +44,6 @@ func runExecutable(executablePath string) (string, error) {
 }
 
 func ex00Test(exercise *Exercise.Exercise) Exercise.Result {
-	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
-
 	if err := ex00Compile(exercise); err != nil {
 		return Exercise.CompilationError(err.Error())
 	}

--- a/internal/tests/R00/ex01.go
+++ b/internal/tests/R00/ex01.go
@@ -52,9 +52,6 @@ func compileWithRustcTestOption(turnInFile string) error {
 }
 
 func ex01Test(exercise *Exercise.Exercise) Exercise.Result {
-	if !testutils.TurnInFilesCheck(*exercise) {
-		return Exercise.Result{Passed: false, Output: "invalid files found in turn in directory"}
-	}
 	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 	if err := testutils.AppendStringToFile(CargoTest, exercise.TurnInFiles[0]); err != nil {
 		logger.Error.Printf("could not write to %s: %v", exercise.TurnInFiles[0], err)

--- a/internal/tests/R00/ex01.go
+++ b/internal/tests/R00/ex01.go
@@ -52,7 +52,6 @@ func compileWithRustcTestOption(turnInFile string) error {
 }
 
 func ex01Test(exercise *Exercise.Exercise) Exercise.Result {
-	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 	if err := testutils.AppendStringToFile(CargoTest, exercise.TurnInFiles[0]); err != nil {
 		logger.Error.Printf("could not write to %s: %v", exercise.TurnInFiles[0], err)
 		return Exercise.InternalError(err.Error())

--- a/internal/tests/R00/ex02.go
+++ b/internal/tests/R00/ex02.go
@@ -161,9 +161,6 @@ func printBytes() Exercise.Result {
 }
 
 func ex02Test(exercise *Exercise.Exercise) Exercise.Result {
-	if !testutils.TurnInFilesCheck(*exercise) {
-		return Exercise.InvalidFileError()
-	}
 	if result := yes(); !result.Passed {
 		return result
 	} 

--- a/internal/tests/R00/ex03.go
+++ b/internal/tests/R00/ex03.go
@@ -49,8 +49,6 @@ func fizzBuzzOutputTest(exercise Exercise.Exercise) Exercise.Result {
 }
 
 func ex03Test(exercise *Exercise.Exercise) Exercise.Result {
-	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
-
 	return fizzBuzzOutputTest(*exercise)
 }
 

--- a/internal/tests/R00/ex03.go
+++ b/internal/tests/R00/ex03.go
@@ -49,9 +49,6 @@ func fizzBuzzOutputTest(exercise Exercise.Exercise) Exercise.Result {
 }
 
 func ex03Test(exercise *Exercise.Exercise) Exercise.Result {
-	if !testutils.TurnInFilesCheck(*exercise) {
-		return Exercise.Result{Passed: false, Output: "invalid files found in turn in directory"}
-	}
 	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 
 	return fizzBuzzOutputTest(*exercise)

--- a/internal/tests/R00/ex04.go
+++ b/internal/tests/R00/ex04.go
@@ -67,9 +67,6 @@ func testCargoRun(exercise Exercise.Exercise) Exercise.Result {
 }
 
 func ex04Test(exercise *Exercise.Exercise) Exercise.Result {
-	if !testutils.TurnInFilesCheck(*exercise) {
-		return Exercise.Result{Passed: false, Output: "invalid files found in turn in directory"}
-	}
 	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 
 	if result := testCargoRun(*exercise); !result.Passed {

--- a/internal/tests/R00/ex04.go
+++ b/internal/tests/R00/ex04.go
@@ -67,8 +67,6 @@ func testCargoRun(exercise Exercise.Exercise) Exercise.Result {
 }
 
 func ex04Test(exercise *Exercise.Exercise) Exercise.Result {
-	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
-
 	if result := testCargoRun(*exercise); !result.Passed {
 		return result
 	}

--- a/internal/tests/R00/ex05.go
+++ b/internal/tests/R00/ex05.go
@@ -6,9 +6,6 @@ import (
 )
 
 func ex05Test(exercise *Exercise.Exercise) Exercise.Result {
-	if !testutils.TurnInFilesCheck(*exercise) {
-		return Exercise.InvalidFileError()
-	}
 	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 	return Exercise.Passed("OK")
 }

--- a/internal/tests/R00/ex05.go
+++ b/internal/tests/R00/ex05.go
@@ -2,11 +2,9 @@ package R00
 
 import (
 	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
-	"github.com/42-Short/shortinette/pkg/testutils"
 )
 
 func ex05Test(exercise *Exercise.Exercise) Exercise.Result {
-	exercise.TurnInFiles = testutils.FullTurnInFilesPath(*exercise)
 	return Exercise.Passed("OK")
 }
 

--- a/pkg/interfaces/exercise/exercise.go
+++ b/pkg/interfaces/exercise/exercise.go
@@ -1,6 +1,10 @@
 package Exercise
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
 
 type Result struct {
 	Passed bool
@@ -66,8 +70,52 @@ func NewExercise(
 	}
 }
 
+func (e *Exercise) fullTurnInFilesPath() []string {
+	var fullFilePaths []string
+
+	for _, path := range e.TurnInFiles {
+		fullPath := filepath.Join(e.RepoDirectory, e.TurnInDirectory, path)
+		fullFilePaths = append(fullFilePaths, fullPath)
+	}
+	return fullFilePaths
+}
+
+func containsString(hayStack []string, needle string) bool {
+	for _, str := range hayStack {
+		if str == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Exercise) turnInFilesCheck() Result {
+	var foundTurnInFiles []string
+	fullTurnInFilesPaths := e.fullTurnInFilesPath()
+	parentDirectory := filepath.Join(e.RepoDirectory, e.TurnInDirectory)
+	err := filepath.Walk(parentDirectory, func(path string, info os.FileInfo, err error) error {
+		if filepath.Base(path)[0] == '.' || path == parentDirectory || info.IsDir() {
+			return nil
+		} else if !containsString(fullTurnInFilesPaths, path) {
+			return fmt.Errorf("'%s' not in allowed turn in files", path)
+		} else {
+			foundTurnInFiles = append(foundTurnInFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return Result{Passed: false, Output: fmt.Sprintf("invalid file(s) found in %s/", e.TurnInDirectory)}
+	} else if len(foundTurnInFiles) != len(fullTurnInFilesPaths) {
+		return Result{Passed: false, Output: fmt.Sprintf("missing files in %s/", e.TurnInDirectory)}
+	}
+	return Result{Passed: true, Output: ""}
+}
+
 // Run runs the Executer function and returns the result
 func (e *Exercise) Run() Result {
+	if result := e.turnInFilesCheck(); !result.Passed {
+		return result
+	}
 	if e.Executer != nil {
 		return e.Executer(e)
 	}

--- a/pkg/interfaces/exercise/exercise.go
+++ b/pkg/interfaces/exercise/exercise.go
@@ -111,11 +111,13 @@ func (e *Exercise) turnInFilesCheck() Result {
 	return Result{Passed: true, Output: ""}
 }
 
-// Run runs the Executer function and returns the result
+// Runs the Executer function and returns the result
 func (e *Exercise) Run() Result {
 	if result := e.turnInFilesCheck(); !result.Passed {
 		return result
 	}
+	e.TurnInFiles = e.fullTurnInFilesPath()
+
 	if e.Executer != nil {
 		return e.Executer(e)
 	}

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -21,10 +21,14 @@ func requireEnv() error {
 		"CONFIG_PATH":         os.Getenv("CONFIG_PATH"),
 		"WEBHOOK_URL":         os.Getenv("WEBHOOK_URL"),
 	}
+	var missingValuesString string
 	for key, value := range vars {
 		if value == "" {
-			return fmt.Errorf("%s environment variable not set", key)
+			missingValuesString += "\n" + key
 		}
+	}
+	if missingValuesString != "" {
+		return fmt.Errorf("missing environment variables:%s\nSee https://github.com/42-Short/shortinette/tree/main/.github/docs/DOTENV.md for details on .env configuration", missingValuesString)
 	}
 	return nil
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -75,6 +75,16 @@ func AppendStringToFile(source string, destFilePath string) error {
 	return nil
 }
 
+func FullTurnInFilesPath(exercise Exercise.Exercise) []string {
+	var fullFilePaths []string
+
+	for _, path := range exercise.TurnInFiles {
+		fullPath := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory, path)
+		fullFilePaths = append(fullFilePaths, fullPath)
+	}
+	return fullFilePaths
+}
+
 // Delete the first occurrence of targetString from filePath
 func DeleteStringFromFile(targetString, filePath string) error {
 	content, err := os.ReadFile(filePath)
@@ -163,39 +173,6 @@ func RunCommandLine(workingDirectory string, command string, args []string, opti
 		return stderr.String(), fmt.Errorf("%v", err)
 	}
 	return stdout.String() + stderr.String(), nil
-}
-
-func containsString(hayStack []string, needle string) bool {
-	for _, str := range hayStack {
-		if str == needle {
-			return true
-		}
-	}
-	return false
-}
-
-func TurnInFilesCheck(exercise Exercise.Exercise) bool {
-	fullTurnInFilesPaths := FullTurnInFilesPath(exercise)
-	parentDirectory := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory)
-	err := filepath.Walk(parentDirectory, func(path string, info os.FileInfo, err error) error {
-		if filepath.Base(path)[0] == '.' || path == parentDirectory || info.IsDir() {
-			return nil
-		} else if !containsString(fullTurnInFilesPaths, path) {
-			return fmt.Errorf("'%s' not in allowed turn in files", path)
-		}
-		return nil
-	})
-	return err == nil
-}
-
-func FullTurnInFilesPath(exercise Exercise.Exercise) []string {
-	var fullFilePaths []string
-
-	for _, path := range exercise.TurnInFiles {
-		fullPath := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory, path)
-		fullFilePaths = append(fullFilePaths, fullPath)
-	}
-	return fullFilePaths
 }
 
 func FullTurnInDirectory(codeDirectory string, exercise Exercise.Exercise) string {

--- a/subjects/R00.md
+++ b/subjects/R00.md
@@ -19,7 +19,7 @@ crates specified in the `allowed dependencies` section are allowed. Any other de
 forbidden. More generally, only the symbols specified in `allowed symbols` are authorized within an
 exercise.
 
-* You are generally *not* authorized to modify lint levels - either using `#\[attributes\]`,
+* You are generally *not* authorized to modify lint levels - either using `#\q[attributes\]`,
 `#!\[global_attributes\]` or with command-line arguments. You may optionally allow the `dead_code`
 lint to silence warnings about unused variables, functions, etc.
 


### PR DESCRIPTION
A lot of checks like invalid/missing turn in files were done at implementation level (i.e we relied on campuses to do it).
They are now abstracted away in the Exercise interface in order to keep the need for custom implementation to a minimum