### PR TITLE
Remove rust specific code from shortinette

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -19,25 +19,6 @@ import (
 	"github.com/42-Short/shortinette/pkg/logger"
 )
 
-// CompileWithRustc compiles a Rust file using the rustc compiler.
-//
-//   - turnInFile: the path to the Rust file to be compiled
-//
-// Returns an error if the compilation fails.
-func CompileWithRustc(turnInFile string) error {
-	cmd := exec.Command("rustc", filepath.Base(turnInFile))
-	cmd.Dir = filepath.Dir(turnInFile)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Error.Println(err)
-		logger.Error.Println(string(output))
-		return err
-	}
-	logger.Info.Printf("%s/%s compiled with rustc\n", cmd.Dir, turnInFile)
-	return nil
-}
-
 // AppendStringToFile appends a source string to a destination file.
 //
 //   - source: the string to append to the file


### PR DESCRIPTION
It doesn't really make sense to leave this rust-specific function in shortinette, so I removed it and added something similar in the R00 module of the Rust tests repo (all other modules use cargo and not rustc directly anyway).