### PR TITLE
add: push to specific branches, create branches

### DIFF
--- a/app/git/git.go
+++ b/app/git/git.go
@@ -74,6 +74,24 @@ func isRepoAlreadyExists(err error) (exists bool) {
 	return false
 }
 
+func initialCommit(name string, commitMessage string) (err error) {
+	if err = os.WriteFile("README.md", []byte(""), os.FileMode(0644)); err != nil {
+		return fmt.Errorf("could not make initial commit '%s': %v", name, err)
+	}
+
+	defer func() {
+		if err = os.RemoveAll("README.md"); err != nil {
+			fmt.Printf("error cleaning up README.md from initial commit: %v", err)
+		}
+	}()
+
+	if err = UploadFiles(name, commitMessage, "main", false, "README.md"); err != nil {
+		return fmt.Errorf("could not make initial commit '%s': %v", name, err)
+	}
+
+	return nil
+}
+
 // Creates a new repository `name` under the GitHub organisation specified by the
 // GITHUB_ORGANISATION environment variable. If `private` is true, the repository's
 // visibility will be private.
@@ -96,6 +114,10 @@ func NewRepo(name string, private bool, description string) (err error) {
 			}
 		}
 		return fmt.Errorf("could not create repo %s: %v", name, err)
+	}
+
+	if err = initialCommit(name, "Initial Commit"); err != nil {
+		return fmt.Errorf("repo was successfully created, but initial commit failed - this could lead to undefined behavior: %v", err)
 	}
 
 	fmt.Printf("repo created: %s at URL: %s\n", *createdRepo.Name, *createdRepo.HTMLURL)
@@ -201,12 +223,17 @@ func copyFiles(target string, files ...string) (err error) {
 	return nil
 }
 
-func checkout(dir string, to string) (err error) {
+func checkout(dir string, to string, createBranch bool) (err error) {
 	if to == "main" {
 		return nil
 	}
 
-	cmd := exec.Command("git", "checkout", to)
+	var cmd *exec.Cmd
+	if createBranch {
+		cmd = exec.Command("git", "checkout", "-b", to)
+	} else {
+		cmd = exec.Command("git", "checkout", to)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = dir
@@ -215,25 +242,29 @@ func checkout(dir string, to string) (err error) {
 		return fmt.Errorf("git checkout %s: %v", to, err)
 	}
 
-	cmd = exec.Command("git", "push", "--set-upstream", "origin", "$(git_current_branch)")
+	cmd = exec.Command("git", "push", "--set-upstream", "origin", to)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = dir
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("git --set-upstream origin $(git_current_branch): %v", err)
+		return fmt.Errorf("git --set-upstream origin %s: %v", to, err)
 	}
 
 	return nil
 }
 
-// Copies `files` into `repoName` and pushes them to the remote. Clones the repo if necessary.
-func UploadFiles(repoName string, commitMessage string, branch string, files ...string) (err error) {
+// Copies `files` into `repoName` and pushes them to the branch `branchName` on the remote.
+//
+// If `createBranch` is set to true, a new branch will be created.
+//
+// Clones the repo if necessary.
+func UploadFiles(repoName string, commitMessage string, branch string, createBranch bool, files ...string) (err error) {
 	if err := Clone(repoName); err != nil {
 		return fmt.Errorf("could not upload files to '%s': %v", repoName, err)
 	}
 
-	if err = checkout(repoName, branch); err != nil {
+	if err = checkout(repoName, branch, createBranch); err != nil {
 		return fmt.Errorf("could not upload files to '%s': %v", repoName, err)
 	}
 

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -202,6 +202,10 @@ func copyFiles(target string, files ...string) (err error) {
 }
 
 func checkout(dir string, to string) (err error) {
+	if to == "main" {
+		return nil
+	}
+
 	cmd := exec.Command("git", "checkout", to)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -86,7 +86,7 @@ func TestUploadFilesNonExistingFiles(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "foo", "bar"); err == nil {
+	if err := UploadFiles("test", "don't mind me just breaking code", "main", "foo", "bar"); err == nil {
 		t.Fatalf("trying to upload non-existing files to a repo should throw an error")
 	}
 }
@@ -105,7 +105,7 @@ func TestUploadFilesNormalFunctionality(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "git.go", "git_test.go"); err != nil {
+	if err := UploadFiles("test", "don't mind me just breaking code", "main", "git.go", "git_test.go"); err != nil {
 		t.Fatalf("uploading an existing file should work, something went wrong: %v", err)
 	}
 
@@ -154,7 +154,7 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "git_test.go"); err != nil {
+	if err := UploadFiles(expectedRepoName, "initial commit", "main", "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestNewReleaseAlreadyExisting(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "git_test.go"); err != nil {
+	if err := UploadFiles(expectedRepoName, "initial commit", "main", "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
@@ -214,3 +214,13 @@ func TestNewReleaseNonExistingrepo(t *testing.T) {
 		t.Fatalf("NewRelease did not return any error when trying to add a release to a non-existing repo")
 	}
 }
+
+// func TestCheckout(t *testing.T) {
+// 	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+// 		t.Fatalf("could not create test repo: %v", err)
+// 	}
+
+// 	if err := UploadFiles("test", "this should work", "main", "git.go"); err != nil {
+// 		t.Fatalf("UploadFiles returned an error on normal usage: %v", err)
+// 	}
+// }

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -86,7 +86,7 @@ func TestUploadFilesNonExistingFiles(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "main", "foo", "bar"); err == nil {
+	if err := UploadFiles("test", "don't mind me just breaking code", "main", false, "foo", "bar"); err == nil {
 		t.Fatalf("trying to upload non-existing files to a repo should throw an error")
 	}
 }
@@ -105,8 +105,66 @@ func TestUploadFilesNormalFunctionality(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "main", "git.go", "git_test.go"); err != nil {
+	if err := UploadFiles("test", "don't mind me just breaking code", "main", false, "git.go", "git_test.go"); err != nil {
 		t.Fatalf("uploading an existing file should work, something went wrong: %v", err)
+	}
+
+	if err := Clone("test"); err != nil {
+		t.Fatalf("could not verify file upload: %v", err)
+	}
+
+	content, err := os.ReadDir("test")
+	if err != nil {
+		t.Fatalf("could not verify file upload: %v", err)
+	}
+
+	found := 0
+	for _, path := range content {
+		if path.Name() == "git.go" || path.Name() == "git_test.go" {
+			found += 1
+		}
+	}
+
+	if found != 2 {
+		t.Fatalf("expected 'git.go' and 'git_test.go' to be uploaded, did not find all of them")
+	}
+}
+
+func TestUploadFilesNonExistingBranch(t *testing.T) {
+	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+		t.Fatalf("could not create test repo: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll("test"); err != nil {
+			t.Fatalf("could not delete test repo (local): %v", err)
+		}
+		if err := deleteRepo("test"); err != nil {
+			t.Fatalf("could not delete test repo (remote): %v", err)
+		}
+	}()
+
+	if err := UploadFiles("test", "don't mind me just breaking code", "thisbranchdoesnotexist", false, "git.go", "git_test.go"); err == nil {
+		t.Fatalf("UploadFiles should return an error when trying to push to unexisting branch")
+	}
+}
+
+func TestUploadFilesNonDefaultBranch(t *testing.T) {
+	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+		t.Fatalf("could not create test repo: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll("test"); err != nil {
+			t.Fatalf("could not delete test repo (local): %v", err)
+		}
+		if err := deleteRepo("test"); err != nil {
+			t.Fatalf("could not delete test repo (remote): %v", err)
+		}
+	}()
+
+	if err := UploadFiles("test", "don't mind me just breaking code", "thisbranchshouldbecreated", true, "git.go", "git_test.go"); err != nil {
+		t.Fatalf("UploadFiles should be able to create a new branch when needed")
 	}
 
 	if err := Clone("test"); err != nil {
@@ -154,7 +212,7 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "main", "git_test.go"); err != nil {
+	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
@@ -196,7 +254,7 @@ func TestNewReleaseAlreadyExisting(t *testing.T) {
 		}
 	}()
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "main", "git_test.go"); err != nil {
+	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
@@ -214,13 +272,3 @@ func TestNewReleaseNonExistingrepo(t *testing.T) {
 		t.Fatalf("NewRelease did not return any error when trying to add a release to a non-existing repo")
 	}
 }
-
-// func TestCheckout(t *testing.T) {
-// 	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
-// 		t.Fatalf("could not create test repo: %v", err)
-// 	}
-
-// 	if err := UploadFiles("test", "this should work", "main", "git.go"); err != nil {
-// 		t.Fatalf("UploadFiles returned an error on normal usage: %v", err)
-// 	}
-// }


### PR DESCRIPTION
Changes:
* `NewRepo` now uploads an empty `README.md` to ensure some data is always on the repo. Robust branch creation is not possible otherwise.
* `UploadFiles` has a new signature: 
```go
UploadFiles(repoName string, commitMessage string, branch string, createBranch bool, files ...string)
```
-> `branch` specifies which remote branch to push to (`main` is default)
-> `createBranch`: set to `false`, `UploadFiles` will just check out to `branch` - set to `true`, it will create it