### PR TITLE
Create repositories from templates

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -32,6 +32,6 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global url."https://${{ secrets.TOKEN_GITHUB }}@github.com".insteadOf "https://github.com/"
       - name: Run tests
-        run: go test ./...
+        run: go test ./... --parallel 5
         working-directory: './app'
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
       ORGA_GITHUB: ${{ secrets.ORGA_GITHUB }}
+      TEMPLATE_REPO: ${{ secrets.TEMPLATE_REPO }}
         
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -32,6 +32,6 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global url."https://${{ secrets.TOKEN_GITHUB }}@github.com".insteadOf "https://github.com/"
       - name: Run tests
-        run: go test ./... --parallel 5
+        run: go test ./... 
         working-directory: './app'
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,7 +13,7 @@ jobs:
       TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
       ORGA_GITHUB: ${{ secrets.ORGA_GITHUB }}
       TEMPLATE_REPO: ${{ secrets.TEMPLATE_REPO }}
-        
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -39,7 +39,7 @@ func deleteRepo(name string) (err error) {
 // Checks for environment variables required to interact with the GitHub API. Returns their values
 // if they exist, sets the error's value if not.
 func requireEnv() (githubToken string, githubOrga string, templateRepo string, err error) {
-	if err := godotenv.Load("../.env", ".env"); err != nil {
+	if err := godotenv.Load("../.env"); err != nil {
 		fmt.Printf("warning: .env file not found, this is expected in the GitHub Actions environment, this is a problem if you are running this locally\n")
 	}
 
@@ -79,24 +79,6 @@ func isRepoAlreadyExists(err error) (exists bool) {
 	return false
 }
 
-func initialCommit(name string, commitMessage string) (err error) {
-	if err = os.WriteFile("README.md", []byte(""), os.FileMode(0644)); err != nil {
-		return fmt.Errorf("could not make initial commit '%s': %v", name, err)
-	}
-
-	defer func() {
-		if err = os.RemoveAll("README.md"); err != nil {
-			fmt.Printf("error cleaning up README.md from initial commit: %v", err)
-		}
-	}()
-
-	if err = UploadFiles(name, commitMessage, "main", false, "README.md"); err != nil {
-		return fmt.Errorf("could not make initial commit '%s': %v", name, err)
-	}
-
-	return nil
-}
-
 // Creates a new repository `name` under the GitHub organisation specified by the
 // GITHUB_ORGANISATION environment variable. If `private` is true, the repository's
 // visibility will be private.
@@ -117,10 +99,6 @@ func NewRepo(name string, private bool, description string) (err error) {
 			}
 		}
 		return fmt.Errorf("could not create repo %s: %v", name, err)
-	}
-
-	if err = initialCommit(name, "Initial Commit"); err != nil {
-		return fmt.Errorf("repo was successfully created, but initial commit failed - this could lead to undefined behavior: %v", err)
 	}
 
 	fmt.Printf("repo created: %s at URL: %s\n", *createdRepo.Name, *createdRepo.HTMLURL)

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -16,7 +16,7 @@ import (
 )
 
 func deleteRepo(name string) (err error) {
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		return fmt.Errorf("could not delete repo '%s': %v", name, err)
 	}
@@ -38,7 +38,7 @@ func deleteRepo(name string) (err error) {
 
 // Checks for environment variables required to interact with the GitHub API. Returns their values
 // if they exist, sets the error's value if not.
-func requireEnv() (githubToken string, githubOrga string, err error) {
+func requireEnv() (githubToken string, githubOrga string, templateRepo string, err error) {
 	if err := godotenv.Load("../.env", ".env"); err != nil {
 		fmt.Printf("warning: .env file not found, this is expected in the GitHub Actions environment, this is a problem if you are running this locally\n")
 	}
@@ -55,18 +55,23 @@ func requireEnv() (githubToken string, githubOrga string, err error) {
 		missingVars = append(missingVars, "ORGA_GITHUB")
 	}
 
+	templateRepo = os.Getenv("TEMPLATE_REPO")
+	if githubOrga == "" {
+		missingVars = append(missingVars, "TEMPLATE_REPO")
+	}
+
 	if len(missingVars) != 0 {
 		err = fmt.Errorf("missing environment variable(s): %s", strings.Join(missingVars, ", "))
 	}
 
-	return githubToken, githubOrga, err
+	return githubToken, githubOrga, templateRepo, err
 }
 
 // Checks whether `err` is related to the repo already existing.
 func isRepoAlreadyExists(err error) (exists bool) {
 	if githubErr, ok := err.(*github.ErrorResponse); ok {
 		for _, e := range githubErr.Errors {
-			if e.Message == "name already exists on this account" {
+			if strings.Contains(e.Message, "Name already exists on this account") {
 				return true
 			}
 		}
@@ -96,16 +101,14 @@ func initialCommit(name string, commitMessage string) (err error) {
 // GITHUB_ORGANISATION environment variable. If `private` is true, the repository's
 // visibility will be private.
 func NewRepo(name string, private bool, description string) (err error) {
-	token, orga, err := requireEnv()
+	token, orga, templateRepo, err := requireEnv()
 	if err != nil {
 		return fmt.Errorf("could not create repo %s: %v", name, err)
 	}
 
 	client := github.NewClient(nil).WithAuthToken(token)
 
-	repo := &github.Repository{Name: &name, Private: &private, Description: &description}
-
-	createdRepo, response, err := client.Repositories.Create(context.Background(), orga, repo)
+	createdRepo, response, err := client.Repositories.CreateFromTemplate(context.Background(), orga, templateRepo, &github.TemplateRepoRequest{Name: &name, Private: &private, Owner: &orga, Description: &description})
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusUnprocessableEntity {
 			if isRepoAlreadyExists(err) {
@@ -127,7 +130,7 @@ func NewRepo(name string, private bool, description string) (err error) {
 // Adds collaborator `collaboratorName` to repo `repoName` (under the GitHub organisation specified by
 // the GITHUB_ORGANISATION environment variable) with access level `permission“.
 func AddCollaborator(repoName string, collaboratorName string, permission string) (err error) {
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		return fmt.Errorf("could not add collaborator %s to repo %s: %v", collaboratorName, repoName, err)
 	}
@@ -154,7 +157,7 @@ func Clone(name string) (err error) {
 		return nil
 	}
 
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		return fmt.Errorf("could not clone '%s': %v", name, err)
 	}
@@ -296,7 +299,7 @@ func UploadFiles(repoName string, commitMessage string, branch string, createBra
 // some content). This should not be an issue for shortinette though, since we always upload subjects when creating
 // the repos.
 func NewRelease(repoName string, tagName string, releaseName string, body string) (err error) {
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		return fmt.Errorf("could not add release '%s', tagged '%s' in repo '%s': %v", releaseName, tagName, repoName, err)
 	}

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -38,7 +38,7 @@ func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 
 	defer cleanup(t, repoName)
 
-	if err := NewRepo(repoName, true, "this should not be created"); err != nil {
+	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}
 }

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v66/github"
+	"github.com/google/uuid"
 )
 
+func cleanup(t *testing.T, repoName string) {
+	if err := os.RemoveAll(repoName); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+	if err := deleteRepo(repoName); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+}
+
 func TestNewRepoNonExistingOrga(t *testing.T) {
+	repoName := uuid.New().String()
+
 	_, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -19,29 +32,35 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 	}
 
 	defer func() {
+		cleanup(t, repoName)
 		if err := os.Setenv("ORGA_GITHUB", orga); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	}()
 
-	if err := NewRepo("test", true, "this should not be created"); err == nil {
+	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}
 }
 
 func TestNewRepoStandardFunctionality(t *testing.T) {
+	t.Parallel()
+
 	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
 
-	expectedRepoName := "fromtemplate"
+	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
 
 	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
+	defer cleanup(t, expectedRepoName)
+
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
 	client := github.NewClient(nil).WithAuthToken(token)
 	repo, _, err := client.Repositories.Get(context.Background(), orga, expectedRepoName)
@@ -61,19 +80,18 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 }
 
 func TestNewRepoAlreadyExisting(t *testing.T) {
-	expectedRepoName := "fromtemplate"
+	t.Parallel()
+
+	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
 
 	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
+	defer cleanup(t, expectedRepoName)
 
-	defer func() {
-		if err := deleteRepo(expectedRepoName); err != nil {
-			t.Fatalf("cleanup failed: %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
 	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo should not error on already exsiting repos: %v", err)
@@ -81,59 +99,77 @@ func TestNewRepoAlreadyExisting(t *testing.T) {
 }
 
 func TestAddCollaboratorNonExistingUser(t *testing.T) {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "idc"); err != nil {
+		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
+	}
+	defer cleanup(t, repoName)
+
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
+
 	if err := AddCollaborator("repo", "ireallydonotthinkthatthisgithubuserexists", "read"); err == nil {
 		t.Fatalf("non-existing user should throw an error")
 	}
 }
 
 func TestAddCollaboratorNonExistingPermission(t *testing.T) {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "idc"); err != nil {
+		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
+	}
+	defer cleanup(t, repoName)
+
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
+
 	if err := AddCollaborator("repo", "winstonallo", "fornicate"); err == nil {
 		t.Fatalf("non-existing permission level should throw an error")
 	}
 }
 
 func TestUploadFilesNonExistingFiles(t *testing.T) {
-	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("error: %v", err)
 	}
+	defer cleanup(t, repoName)
 
-	defer func() {
-		if err := os.RemoveAll("test"); err != nil {
-			t.Fatalf("error: %v", err)
-		}
-		if err := deleteRepo("test"); err != nil {
-			t.Fatalf("error: %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "main", false, "foo", "bar"); err == nil {
+	if err := UploadFiles(repoName, "don't mind me just breaking code", "main", false, "foo", "bar"); err == nil {
 		t.Fatalf("trying to upload non-existing files to a repo should throw an error")
 	}
 }
 
 func TestUploadFilesNormalFunctionality(t *testing.T) {
-	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
+	defer cleanup(t, repoName)
 
-	defer func() {
-		if err := os.RemoveAll("test"); err != nil {
-			t.Fatalf("could not delete test repo (local): %v", err)
-		}
-		if err := deleteRepo("test"); err != nil {
-			t.Fatalf("could not delete test repo (remote): %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "main", false, "git.go", "git_test.go"); err != nil {
+	if err := UploadFiles(repoName, "don't mind me just breaking code", "main", false, "git.go", "git_test.go"); err != nil {
 		t.Fatalf("uploading an existing file should work, something went wrong: %v", err)
 	}
 
-	if err := Clone("test"); err != nil {
+	if err := Clone(repoName); err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
 
-	content, err := os.ReadDir("test")
+	content, err := os.ReadDir(repoName)
 	if err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
@@ -151,47 +187,43 @@ func TestUploadFilesNormalFunctionality(t *testing.T) {
 }
 
 func TestUploadFilesNonExistingBranch(t *testing.T) {
-	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
+	defer cleanup(t, repoName)
 
-	defer func() {
-		if err := os.RemoveAll("test"); err != nil {
-			t.Fatalf("could not delete test repo (local): %v", err)
-		}
-		if err := deleteRepo("test"); err != nil {
-			t.Fatalf("could not delete test repo (remote): %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "thisbranchdoesnotexist", false, "git.go", "git_test.go"); err == nil {
+	if err := UploadFiles(repoName, "don't mind me just breaking code", "thisbranchdoesnotexist", false, "git.go", "git_test.go"); err == nil {
 		t.Fatalf("UploadFiles should return an error when trying to push to unexisting branch")
 	}
 }
 
 func TestUploadFilesNonDefaultBranch(t *testing.T) {
-	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
+	defer cleanup(t, repoName)
 
-	defer func() {
-		if err := os.RemoveAll("test"); err != nil {
-			t.Fatalf("could not delete test repo (local): %v", err)
-		}
-		if err := deleteRepo("test"); err != nil {
-			t.Fatalf("could not delete test repo (remote): %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles("test", "don't mind me just breaking code", "thisbranchshouldbecreated", true, "git.go", "git_test.go"); err != nil {
+	if err := UploadFiles(repoName, "don't mind me just breaking code", "thisbranchshouldbecreated", true, "git.go", "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles should be able to create a new branch when needed")
 	}
 
-	if err := Clone("test"); err != nil {
+	if err := Clone(repoName); err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
 
-	content, err := os.ReadDir("test")
+	content, err := os.ReadDir(repoName)
 	if err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
@@ -209,12 +241,14 @@ func TestUploadFilesNonDefaultBranch(t *testing.T) {
 }
 
 func TestNewReleaseNormalFunctionality(t *testing.T) {
+	t.Parallel()
+
 	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
 
-	expectedRepoName := "test"
+	expectedRepoName := uuid.New().String()
 	expectedTagName := "tag"
 	expectedReleaseName := "release"
 	expectedBody := "body"
@@ -222,15 +256,9 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 	if err := NewRepo(expectedRepoName, true, "this will be deleted soon"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
+	defer cleanup(t, expectedRepoName)
 
-	defer func() {
-		if err := os.RemoveAll(expectedRepoName); err != nil {
-			t.Fatalf("could not delete test repo (local): %v", err)
-		}
-		if err := deleteRepo(expectedRepoName); err != nil {
-			t.Fatalf("could not delete test repo (remote): %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
 	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
@@ -259,35 +287,40 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 }
 
 func TestNewReleaseAlreadyExisting(t *testing.T) {
-	expectedRepoName := "test"
+	t.Parallel()
 
-	if err := NewRepo("test", true, "this will be deleted soon_GITHUB"); err != nil {
+	expectedRepoName := uuid.New().String()
+
+	if err := NewRepo(expectedRepoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
+	defer cleanup(t, expectedRepoName)
 
-	defer func() {
-		if err := os.RemoveAll("test"); err != nil {
-			t.Fatalf("could not delete test repo (local): %v", err)
-		}
-		if err := deleteRepo("test"); err != nil {
-			t.Fatalf("could not delete test repo (remote): %v", err)
-		}
-	}()
+	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
 	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
-	if err := NewRelease("test", "tag", "release", "body"); err != nil {
+	if err := NewRelease(expectedRepoName, "tag", "release", "body"); err != nil {
 		t.Fatalf("NewRelease returned an error on a standard use case: %v", err)
 	}
 
-	if err := NewRelease("test", "tag", "release", "body"); err == nil {
+	if err := NewRelease(expectedRepoName, "tag", "release", "body"); err == nil {
 		t.Fatalf("duplicate tag names should return an error")
 	}
 }
 
 func TestNewReleaseNonExistingrepo(t *testing.T) {
+	t.Parallel()
+
+	repoName := uuid.New().String()
+
+	if err := NewRepo(repoName, true, "idc"); err != nil {
+		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
+	}
+	defer cleanup(t, repoName)
+
 	if err := NewRelease("thisrepodoesnotexist", "tag", "release", "body"); err == nil {
 		t.Fatalf("NewRelease did not return any error when trying to add a release to a non-existing repo")
 	}

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -22,21 +22,9 @@ func cleanup(t *testing.T, repoName string) {
 func TestNewRepoNonExistingOrga(t *testing.T) {
 	repoName := uuid.New().String()
 
-	_, orga, _, err := requireEnv()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
+	defer cleanup(t, repoName)
 
-	if err := os.Setenv("ORGA_GITHUB", "thisorgadoesnoteist"); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	defer func() {
-		cleanup(t, repoName)
-		if err := os.Setenv("ORGA_GITHUB", orga); err != nil {
-			t.Fatalf("error: %v", err)
-		}
-	}()
+	t.Setenv("ORGA_GITHUB", "thisorgadoesnoteist")
 
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
@@ -46,41 +34,17 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 	repoName := uuid.New().String()
 
-	_, orga, _, err := requireEnv()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
+	t.Setenv("ORGA_GITHUB", "")
 
-	if err := os.Unsetenv("ORGA_GITHUB"); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	defer func() {
-		cleanup(t, repoName)
-		if err := os.Setenv("ORGA_GITHUB", orga); err != nil {
-			t.Fatalf("error: %v", err)
-		}
-	}()
+	defer cleanup(t, repoName)
 
 	if err := NewRepo(repoName, true, "this should not be created"); err != nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}
 }
 
-func TestNewRepoStandardFunctionality(t *testing.T) {
-	_, _, templateRepo, err := requireEnv()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	if err := os.Setenv("TEMPLATE_REPO", "thistemplatedoesnotexist"); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-	defer func() {
-		if err := os.Setenv("TEMPLATE_REPO", templateRepo); err != nil {
-			t.Fatalf("error: %v", err)
-		}
-	}()
+func TestNewRepoNonExistingTemplate(t *testing.T) {
+	t.Setenv("TEMPLATE_REPO", "thistemplatedoesnotexist")
 
 	expectedRepoName := uuid.New().String()
 
@@ -89,7 +53,7 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 	}
 }
 
-func TestNewRepoNonExistingTemplate(t *testing.T) {
+func TestNewRepoStandardFunctionality(t *testing.T) {
 	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -124,8 +88,6 @@ func TestNewRepoNonExistingTemplate(t *testing.T) {
 }
 
 func TestNewRepoAlreadyExisting(t *testing.T) {
-	t.Parallel()
-
 	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
@@ -143,8 +105,6 @@ func TestNewRepoAlreadyExisting(t *testing.T) {
 }
 
 func TestAddCollaboratorNonExistingUser(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "idc"); err != nil {
@@ -160,8 +120,6 @@ func TestAddCollaboratorNonExistingUser(t *testing.T) {
 }
 
 func TestAddCollaboratorNonExistingPermission(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "idc"); err != nil {
@@ -177,8 +135,6 @@ func TestAddCollaboratorNonExistingPermission(t *testing.T) {
 }
 
 func TestUploadFilesNonExistingFiles(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
@@ -194,8 +150,6 @@ func TestUploadFilesNonExistingFiles(t *testing.T) {
 }
 
 func TestUploadFilesNormalFunctionality(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
@@ -231,8 +185,6 @@ func TestUploadFilesNormalFunctionality(t *testing.T) {
 }
 
 func TestUploadFilesNonExistingBranch(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
@@ -248,8 +200,6 @@ func TestUploadFilesNonExistingBranch(t *testing.T) {
 }
 
 func TestUploadFilesNonDefaultBranch(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
@@ -285,8 +235,6 @@ func TestUploadFilesNonDefaultBranch(t *testing.T) {
 }
 
 func TestNewReleaseNormalFunctionality(t *testing.T) {
-	t.Parallel()
-
 	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -331,8 +279,6 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 }
 
 func TestNewReleaseAlreadyExisting(t *testing.T) {
-	t.Parallel()
-
 	expectedRepoName := uuid.New().String()
 
 	if err := NewRepo(expectedRepoName, true, "this will be deleted soon_GITHUB"); err != nil {
@@ -356,8 +302,6 @@ func TestNewReleaseAlreadyExisting(t *testing.T) {
 }
 
 func TestNewReleaseNonExistingrepo(t *testing.T) {
-	t.Parallel()
-
 	repoName := uuid.New().String()
 
 	if err := NewRepo(repoName, true, "idc"); err != nil {

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewRepoNonExistingOrga(t *testing.T) {
-	_, orga, err := requireEnv()
+	_, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -30,12 +30,12 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 }
 
 func TestNewRepoStandardFunctionality(t *testing.T) {
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
 
-	expectedRepoName := "repository"
+	expectedRepoName := "fromtemplate"
 	expectedPrivate := true
 	expectedDescription := "description"
 
@@ -57,6 +57,26 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 	}
 	if repo.GetDescription() != expectedDescription {
 		t.Fatalf("repo description was not set correctly: expected: '%s', got: '%s'", expectedDescription, repo.GetDescription())
+	}
+}
+
+func TestNewRepoAlreadyExisting(t *testing.T) {
+	expectedRepoName := "fromtemplate"
+	expectedPrivate := true
+	expectedDescription := "description"
+
+	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
+		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
+	}
+
+	defer func() {
+		if err := deleteRepo(expectedRepoName); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
+
+	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
+		t.Fatalf("NewRepo should not error on already exsiting repos: %v", err)
 	}
 }
 
@@ -189,7 +209,7 @@ func TestUploadFilesNonDefaultBranch(t *testing.T) {
 }
 
 func TestNewReleaseNormalFunctionality(t *testing.T) {
-	token, orga, err := requireEnv()
+	token, orga, _, err := requireEnv()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -36,8 +36,6 @@ func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 
 	t.Setenv("ORGA_GITHUB", "")
 
-	defer cleanup(t, repoName)
-
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}

--- a/app/go.mod
+++ b/app/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-github/v66 v66.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -30,6 +30,8 @@ github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+Mf
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
Following the suggestion of @FelixBrgm to use devcontainers for isolated development environments, I changed the `git` module to build repos from templates. This will allow us to have a template for each module, easily customizable without having to touch the code.
A welcome side-effect is also 1 less request per repository creation.

PS: I got rate-limited while trying to make the tests run in parallel (I don't learn smh), the CI should pass in ~1 hour when the rate limit is removed.