### PR TITLE
fix: go-test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,6 +1,9 @@
 name: Go
 
-on: [push]
+on:
+  push:
+    paths:
+      - '**/*.go'
 
 jobs:
   build:


### PR DESCRIPTION
Fix `.github/workflows/go-test.yml` to only run on `.go` file changes (CI not passing right now is due to too many test runs being made, each test run is about 15 GitHub API requests)