### PR TITLE
Jakobus42/refactor/config

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         go-version: [ '*' ]
     env:
-      GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
-      GITHUB_ORGA: ${{ secrets.ORGA_GITHUB }}
+      TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
+      ORGA_GITHUB: ${{ secrets.ORGA_GITHUB }}
       TEMPLATE_REPO: ${{ secrets.TEMPLATE_REPO }}
       SERVER_ADDR: ${{ secrets.SERVER_ADDR }}
       CONFIG_PATH: ${{ secrets.CONFIG_PATH }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,9 +13,12 @@ jobs:
       matrix:
         go-version: [ '*' ]
     env:
-      TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
-      ORGA_GITHUB: ${{ secrets.ORGA_GITHUB }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ORGA: ${{ secrets.GITHUB_ORGA }}
       TEMPLATE_REPO: ${{ secrets.TEMPLATE_REPO }}
+      SERVER_ADDR: ${{ secrets.SERVER_ADDR }}
+      CONFIG_PATH: ${{ secrets.CONFIG_PATH }}
+      API_TOKEN: ${{ secrets.API_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +38,5 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global url."https://${{ secrets.TOKEN_GITHUB }}@github.com".insteadOf "https://github.com/"
       - name: Run tests
-        run: go test ./... 
+        run: go test ./...
         working-directory: './app'
-

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         go-version: [ '*' ]
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_ORGA: ${{ secrets.GITHUB_ORGA }}
+      GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+      GITHUB_ORGA: ${{ secrets.ORGA_GITHUB }}
       TEMPLATE_REPO: ${{ secrets.TEMPLATE_REPO }}
       SERVER_ADDR: ${{ secrets.SERVER_ADDR }}
       CONFIG_PATH: ${{ secrets.CONFIG_PATH }}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	Modules      []Module
 
 	TEMPLATE_REPO string
-	GITHUB_TOKEN  string
-	GITHUB_ORGA   string
+	TOKEN_GITHUB  string
+	ORGA_GITHUB   string
 	SERVER_ADDR   string
 	API_TOKEN     string
 	CONFIG_PATH   string
@@ -58,8 +58,8 @@ func init() {
 
 	requiredEnvVars := map[string]*string{
 		"TEMPLATE_REPO": &C.TEMPLATE_REPO,
-		"GITHUB_TOKEN":  &C.GITHUB_TOKEN,
-		"GITHUB_ORGA":   &C.GITHUB_ORGA,
+		"TOKEN_GITHUB":  &C.TOKEN_GITHUB,
+		"ORGA_GITHUB":   &C.ORGA_GITHUB,
 		"API_TOKEN":     &C.API_TOKEN,
 		"SERVER_ADDR":   &C.SERVER_ADDR,
 		"CONFIG_PATH":   &C.CONFIG_PATH,

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -109,7 +109,7 @@ func (config *Config) LoadParticipants(participantsConfigPath string) error {
 //
 //   - exercises: list of single exercises
 //   - minimumScore: minimum score needed to pass the module
-func (config *Config) NewModule(exercises []Exercise, minimumScore int) (mod *Module, err error) {
+func NewModule(exercises []Exercise, minimumScore int) (mod *Module, err error) {
 	if exercises == nil || len(exercises) < 1 {
 		return nil, fmt.Errorf("you need at least one exercise to initialize a module")
 	}
@@ -137,7 +137,7 @@ func (config *Config) NewModule(exercises []Exercise, minimumScore int) (mod *Mo
 //   - score: score given when passing this exercise
 //   - allowedFiles: files allowed to be found in this exercise's directory
 //   - the repository's in which the exercise files are expected to be found
-func (config *Config) NewExercise(executablePath string, score int, allowedFiles []string, turnInDirectory string) (ex *Exercise, err error) {
+func NewExercise(executablePath string, score int, allowedFiles []string, turnInDirectory string) (ex *Exercise, err error) {
 	if allowedFiles == nil || len(allowedFiles) < 1 {
 		return nil, fmt.Errorf("at least one allowed file required")
 	}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -99,6 +99,7 @@ func (config *Config) LoadParticipants(participantsConfigPath string) error {
 			return fmt.Errorf("participant information incomplete")
 		}
 	}
+
 	return nil
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -99,7 +99,6 @@ func (config *Config) LoadParticipants(participantsConfigPath string) error {
 			return fmt.Errorf("participant information incomplete")
 		}
 	}
-
 	return nil
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -11,12 +11,14 @@ import (
 	"github.com/joho/godotenv"
 )
 
+//TODO: should be part of the short package
+//	ModuleDuration time.Duration
+//	StartTime      time.Time
+
 // Main struct, containing all necessary metadata
 type Config struct {
-	Participants   []Participant
-	Modules        []Module
-	ModuleDuration time.Duration
-	StartTime      time.Time
+	Participants []Participant
+	Modules      []Module
 
 	TEMPLATE_REPO string
 	GITHUB_TOKEN  string

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -1,23 +1,43 @@
 package config
 
 import (
+	"os"
 	"testing"
+	"time"
 )
 
+func TestFetchEnvVariables(t *testing.T) {
+	c := NewConfig([]Participant{}, []Module{}, 0, time.Now())
+	if err := c.FetchEnvVariables(); err != nil {
+		t.Fatalf("failed to fetch env variables")
+	}
+}
+
+func TestFetchEnvVariablesMissing(t *testing.T) {
+	os.Setenv("ORGA_GITHUB", "")
+	c := NewConfig([]Participant{}, []Module{}, 0, time.Now())
+	if err := c.FetchEnvVariables(); err == nil {
+		t.Fatalf("missing env vars should throw an error")
+	}
+}
+
 func TestNewParticipantsNonExistingJsonPath(t *testing.T) {
-	if err := C.LoadParticipants("foo"); err == nil {
+	c := NewConfig([]Participant{}, []Module{}, 0, time.Now())
+	if err := c.FetchParticipants("foo"); err == nil {
 		t.Fatalf("a non-existing participants list should throw an error")
 	}
 }
 
 func TestNewParticipantsMalformedJson(t *testing.T) {
-	if err := C.LoadParticipants(("config/malformed.json")); err == nil {
+	c := NewConfig([]Participant{}, []Module{}, 0, time.Now())
+	if err := c.FetchParticipants("config/malformed.json"); err == nil {
 		t.Fatalf("a malformed participants list should throw an error")
 	}
 }
 
 func TestNewParticipantsEmptyList(t *testing.T) {
-	if err := C.LoadParticipants(("config/empty.json")); err == nil {
+	c := NewConfig([]Participant{}, []Module{}, 0, time.Now())
+	if err := c.FetchParticipants("config/empty.json"); err == nil {
 		t.Fatalf("an empty participants list should throw an error")
 	}
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -23,63 +23,63 @@ func TestNewParticipantsEmptyList(t *testing.T) {
 }
 
 func TestNewExerciseEmptyExecutablePath(t *testing.T) {
-	if _, err := C.NewExercise("", 10, []string{"foo"}, "bar"); err == nil {
+	if _, err := NewExercise("", 10, []string{"foo"}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with an empty executable path")
 	}
 }
 
 func TestNewExerciseEmptyTurnInDirectory(t *testing.T) {
-	if _, err := C.NewExercise("foo", 10, []string{"bar"}, ""); err == nil {
+	if _, err := NewExercise("foo", 10, []string{"bar"}, ""); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with an turn in directory")
 	}
 }
 
 func TestNewExerciseNoAllowedFiles(t *testing.T) {
-	if _, err := C.NewExercise("foo", 10, []string{}, "bar"); err == nil {
+	if _, err := NewExercise("foo", 10, []string{}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with no allowed files")
 	}
 }
 
 func TestNewExerciseNilAllowedFiles(t *testing.T) {
-	if _, err := C.NewExercise("foo", 10, nil, "bar"); err == nil {
+	if _, err := NewExercise("foo", 10, nil, "bar"); err == nil {
 		t.Fatalf("allowedFiles cannot be nil")
 	}
 }
 
 func TestNewExerciseNegativeScore(t *testing.T) {
-	if _, err := C.NewExercise("foo", -10, []string{"bar"}, "bar"); err == nil {
+	if _, err := NewExercise("foo", -10, []string{"bar"}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with negative score")
 	}
 }
 
 func TestNewModuleNotEnoughTotalPoints(t *testing.T) {
-	ex, _ := C.NewExercise("foo", 10, []string{"bar"}, "bar")
+	ex, _ := NewExercise("foo", 10, []string{"bar"}, "bar")
 	exercises := []Exercise{
 		0: *ex,
 	}
-	if _, err := C.NewModule(exercises, 20); err == nil {
+	if _, err := NewModule(exercises, 20); err == nil {
 		t.Fatalf("the score of all exercises should add up to the minimum score required to pass (or more)")
 	}
 }
 
 func TestNewModuleNegativeMinimumScore(t *testing.T) {
-	ex, _ := C.NewExercise("foo", 10, []string{"bar"}, "bar")
+	ex, _ := NewExercise("foo", 10, []string{"bar"}, "bar")
 	exercises := []Exercise{
 		0: *ex,
 	}
-	if _, err := C.NewModule(exercises, -20); err == nil {
+	if _, err := NewModule(exercises, -20); err == nil {
 		t.Fatalf("minimumScore cannot be negative")
 	}
 }
 
 func TestNewModuleNoExercises(t *testing.T) {
-	if _, err := C.NewModule([]Exercise{}, 0); err == nil {
+	if _, err := NewModule([]Exercise{}, 0); err == nil {
 		t.Fatalf("it should not be possible to initialize a module with no exercises")
 	}
 }
 
 func TestNewModuleNilExercises(t *testing.T) {
-	if _, err := C.NewModule(nil, 0); err == nil {
+	if _, err := NewModule(nil, 0); err == nil {
 		t.Fatalf("exercises cannot be nil")
 	}
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -2,106 +2,84 @@ package config
 
 import (
 	"testing"
-	"time"
 )
 
 func TestNewParticipantsNonExistingJsonPath(t *testing.T) {
-	if _, err := NewParticipants("foo"); err == nil {
+	if err := C.LoadParticipants("foo"); err == nil {
 		t.Fatalf("a non-existing participants list should throw an error")
 	}
 }
 
 func TestNewParticipantsMalformedJson(t *testing.T) {
-	if _, err := NewParticipants("config/malformed.json"); err == nil {
+	if err := C.LoadParticipants(("config/malformed.json")); err == nil {
 		t.Fatalf("a malformed participants list should throw an error")
 	}
 }
 
 func TestNewParticipantsEmptyList(t *testing.T) {
-	if _, err := NewParticipants("config/empty.json"); err == nil {
+	if err := C.LoadParticipants(("config/empty.json")); err == nil {
 		t.Fatalf("an empty participants list should throw an error")
 	}
 }
 
 func TestNewExerciseEmptyExecutablePath(t *testing.T) {
-	if _, err := NewExercise("", 10, []string{"foo"}, "bar"); err == nil {
+	if _, err := C.NewExercise("", 10, []string{"foo"}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with an empty executable path")
 	}
 }
 
 func TestNewExerciseEmptyTurnInDirectory(t *testing.T) {
-	if _, err := NewExercise("foo", 10, []string{"bar"}, ""); err == nil {
+	if _, err := C.NewExercise("foo", 10, []string{"bar"}, ""); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with an turn in directory")
 	}
 }
 
 func TestNewExerciseNoAllowedFiles(t *testing.T) {
-	if _, err := NewExercise("foo", 10, []string{}, "bar"); err == nil {
+	if _, err := C.NewExercise("foo", 10, []string{}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with no allowed files")
 	}
 }
 
 func TestNewExerciseNilAllowedFiles(t *testing.T) {
-	if _, err := NewExercise("foo", 10, nil, "bar"); err == nil {
+	if _, err := C.NewExercise("foo", 10, nil, "bar"); err == nil {
 		t.Fatalf("allowedFiles cannot be nil")
 	}
 }
 
 func TestNewExerciseNegativeScore(t *testing.T) {
-	if _, err := NewExercise("foo", -10, []string{"bar"}, "bar"); err == nil {
+	if _, err := C.NewExercise("foo", -10, []string{"bar"}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with negative score")
 	}
 }
 
 func TestNewModuleNotEnoughTotalPoints(t *testing.T) {
-	ex, _ := NewExercise("foo", 10, []string{"bar"}, "bar")
+	ex, _ := C.NewExercise("foo", 10, []string{"bar"}, "bar")
 	exercises := []Exercise{
 		0: *ex,
 	}
-	if _, err := NewModule(exercises, 20); err == nil {
+	if _, err := C.NewModule(exercises, 20); err == nil {
 		t.Fatalf("the score of all exercises should add up to the minimum score required to pass (or more)")
 	}
 }
 
 func TestNewModuleNegativeMinimumScore(t *testing.T) {
-	ex, _ := NewExercise("foo", 10, []string{"bar"}, "bar")
+	ex, _ := C.NewExercise("foo", 10, []string{"bar"}, "bar")
 	exercises := []Exercise{
 		0: *ex,
 	}
-	if _, err := NewModule(exercises, -20); err == nil {
+	if _, err := C.NewModule(exercises, -20); err == nil {
 		t.Fatalf("minimumScore cannot be negative")
 	}
 }
 
 func TestNewModuleNoExercises(t *testing.T) {
-	if _, err := NewModule([]Exercise{}, 0); err == nil {
+	if _, err := C.NewModule([]Exercise{}, 0); err == nil {
 		t.Fatalf("it should not be possible to initialize a module with no exercises")
 	}
 }
 
 func TestNewModuleNilExercises(t *testing.T) {
-	if _, err := NewModule(nil, 0); err == nil {
+	if _, err := C.NewModule(nil, 0); err == nil {
 		t.Fatalf("exercises cannot be nil")
-	}
-}
-
-func TestNewShortNegativeDuration(t *testing.T) {
-	ex, _ := NewExercise("foo", 10, []string{"bar"}, "bar")
-	mod, _ := NewModule([]Exercise{0: *ex}, 10)
-
-	if _, err := NewShort([]Module{0: *mod}, time.Hour*-24, time.Now()); err == nil {
-		t.Fatalf("moduleDuration should not be negative")
-	}
-}
-
-func TestNewShortNoModules(t *testing.T) {
-	if _, err := NewShort([]Module{}, time.Hour*24, time.Now()); err == nil {
-		t.Fatalf("should not be possible to initialize a Short with no modules")
-	}
-}
-
-func TestNewShortNilModules(t *testing.T) {
-	if _, err := NewShort(nil, time.Hour*24, time.Now()); err == nil {
-		t.Fatalf("modules cannot be nil")
 	}
 }

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -17,13 +17,13 @@ import (
 )
 
 func deleteRepo(name string) (err error) {
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
 
-	if resp, err := client.Repositories.Delete(context.Background(), config.C.GITHUB_ORGA, name); err != nil {
+	if resp, err := client.Repositories.Delete(context.Background(), config.C.ORGA_GITHUB, name); err != nil {
 		if resp.StatusCode != http.StatusNotFound {
 			return fmt.Errorf("could not delete repo '%s': %v", name, err)
 		} else {
-			logger.Warning.Printf("repo '%s' not found in orga '%s'\n", name, config.C.GITHUB_ORGA)
+			logger.Warning.Printf("repo '%s' not found in orga '%s'\n", name, config.C.ORGA_GITHUB)
 			return nil
 		}
 	}
@@ -48,13 +48,13 @@ func isRepoAlreadyExists(err error) (exists bool) {
 // GITHUB_ORGANISATION environment variable. If `private` is true, the repository's
 // visibility will be private.
 func NewRepo(name string, private bool, description string) (err error) {
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
 
-	createdRepo, response, err := client.Repositories.CreateFromTemplate(context.Background(), config.C.GITHUB_ORGA, config.C.TEMPLATE_REPO, &github.TemplateRepoRequest{Name: &name, Private: &private, Owner: &config.C.GITHUB_ORGA, Description: &description})
+	createdRepo, response, err := client.Repositories.CreateFromTemplate(context.Background(), config.C.ORGA_GITHUB, config.C.TEMPLATE_REPO, &github.TemplateRepoRequest{Name: &name, Private: &private, Owner: &config.C.ORGA_GITHUB, Description: &description})
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusUnprocessableEntity {
 			if isRepoAlreadyExists(err) {
-				logger.Info.Printf("repo %s already exists under orga %s, skipping\n", name, config.C.GITHUB_ORGA)
+				logger.Info.Printf("repo %s already exists under orga %s, skipping\n", name, config.C.ORGA_GITHUB)
 				return nil
 			}
 		}
@@ -68,13 +68,13 @@ func NewRepo(name string, private bool, description string) (err error) {
 // Adds collaborator `collaboratorName` to repo `repoName` (under the GitHub organisation specified by
 // the GITHUB_ORGANISATION environment variable) with access level `permission“.
 func AddCollaborator(repoName string, collaboratorName string, permission string) (err error) {
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
 
 	options := &github.RepositoryAddCollaboratorOptions{
 		Permission: permission,
 	}
 
-	if _, _, err = client.Repositories.AddCollaborator(context.Background(), config.C.GITHUB_ORGA, repoName, collaboratorName, options); err != nil {
+	if _, _, err = client.Repositories.AddCollaborator(context.Background(), config.C.ORGA_GITHUB, repoName, collaboratorName, options); err != nil {
 		return fmt.Errorf("could not add collaborator %s to repo %s: %v", collaboratorName, repoName, err)
 	}
 
@@ -90,7 +90,7 @@ func Clone(name string) (err error) {
 		return nil
 	}
 
-	cloneURL := fmt.Sprintf("https://%s@github.com/%s/%s.git", config.C.GITHUB_TOKEN, config.C.GITHUB_ORGA, name)
+	cloneURL := fmt.Sprintf("https://%s@github.com/%s/%s.git", config.C.TOKEN_GITHUB, config.C.ORGA_GITHUB, name)
 
 	cmd := exec.Command("git", "clone", cloneURL)
 	cmd.Stdout = os.Stdout
@@ -227,10 +227,10 @@ func UploadFiles(repoName string, commitMessage string, branch string, createBra
 // some content). This should not be an issue for shortinette though, since we always upload subjects when creating
 // the repos.
 func NewRelease(repoName string, tagName string, releaseName string, body string) (err error) {
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
 
 	makeLatest := "true"
-	if _, _, err := client.Repositories.CreateRelease(context.Background(), config.C.GITHUB_ORGA, repoName, &github.RepositoryRelease{
+	if _, _, err := client.Repositories.CreateRelease(context.Background(), config.C.ORGA_GITHUB, repoName, &github.RepositoryRelease{
 		Name:       &releaseName,
 		Body:       &body,
 		TagName:    &tagName,

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -25,7 +25,11 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 
 	defer cleanup(t, repoName)
 
+	orgaName := config.C.ORGA_GITHUB
 	config.C.ORGA_GITHUB = "thisorgadoesnoteist"
+	defer func(orgaName string) {
+		config.C.ORGA_GITHUB = orgaName
+	}(orgaName)
 
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
@@ -35,7 +39,11 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 	repoName := uuid.New().String()
 
+	orgaName := config.C.ORGA_GITHUB
 	config.C.ORGA_GITHUB = ""
+	defer func(orgaName string) {
+		config.C.ORGA_GITHUB = orgaName
+	}(orgaName)
 
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
@@ -43,7 +51,12 @@ func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 }
 
 func TestNewRepoNonExistingTemplate(t *testing.T) {
+	templateRepoName := config.C.TEMPLATE_REPO
 	config.C.TEMPLATE_REPO = "thistemplatedoesnotexist"
+	defer func(templateRepoName string) {
+		config.C.TEMPLATE_REPO = templateRepoName
+	}(templateRepoName)
+
 	expectedRepoName := uuid.New().String()
 
 	if err := NewRepo(expectedRepoName, true, "expectedDescription"); err == nil {

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/go-github/v66/github"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -316,7 +318,7 @@ func TestNewReleaseNonExistingrepo(t *testing.T) {
 	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := gh.NewRepo(os.Getenv("TEMPLATE_REPO"), repoName, true, "idc"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "idc"); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
 	defer cleanup(t, gh, repoName)

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -64,8 +64,8 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
-	repo, _, err := client.Repositories.Get(context.Background(), config.C.GITHUB_ORGA, expectedRepoName)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
+	repo, _, err := client.Repositories.Get(context.Background(), config.C.ORGA_GITHUB, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify repo creation: %v", err)
 	}
@@ -249,9 +249,9 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 		t.Fatalf("NewRelease returned an error on a standard use case: %v", err)
 	}
 
-	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
 
-	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), config.C.GITHUB_ORGA, expectedRepoName)
+	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), config.C.ORGA_GITHUB, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify release update: %v", err)
 	}

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/42-Short/shortinette/config"
 	"github.com/google/go-github/v66/github"
 	"github.com/google/uuid"
 )
@@ -52,11 +53,6 @@ func TestNewRepoNonExistingTemplate(t *testing.T) {
 }
 
 func TestNewRepoStandardFunctionality(t *testing.T) {
-	token, orga, _, err := requireEnv()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
 	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
@@ -68,8 +64,8 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	client := github.NewClient(nil).WithAuthToken(token)
-	repo, _, err := client.Repositories.Get(context.Background(), orga, expectedRepoName)
+	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
+	repo, _, err := client.Repositories.Get(context.Background(), config.C.GITHUB_ORGA, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify repo creation: %v", err)
 	}
@@ -233,11 +229,6 @@ func TestUploadFilesNonDefaultBranch(t *testing.T) {
 }
 
 func TestNewReleaseNormalFunctionality(t *testing.T) {
-	token, orga, _, err := requireEnv()
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
 	expectedRepoName := uuid.New().String()
 	expectedTagName := "tag"
 	expectedReleaseName := "release"
@@ -258,9 +249,9 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 		t.Fatalf("NewRelease returned an error on a standard use case: %v", err)
 	}
 
-	client := github.NewClient(nil).WithAuthToken(token)
+	client := github.NewClient(nil).WithAuthToken(config.C.GITHUB_TOKEN)
 
-	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), orga, expectedRepoName)
+	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), config.C.GITHUB_ORGA, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify release update: %v", err)
 	}

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -25,7 +25,7 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 
 	defer cleanup(t, repoName)
 
-	t.Setenv("ORGA_GITHUB", "thisorgadoesnoteist")
+	config.C.ORGA_GITHUB = "thisorgadoesnoteist"
 
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
@@ -35,7 +35,7 @@ func TestNewRepoNonExistingOrga(t *testing.T) {
 func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 	repoName := uuid.New().String()
 
-	t.Setenv("ORGA_GITHUB", "")
+	config.C.ORGA_GITHUB = ""
 
 	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
@@ -43,8 +43,7 @@ func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
 }
 
 func TestNewRepoNonExistingTemplate(t *testing.T) {
-	t.Setenv("TEMPLATE_REPO", "thistemplatedoesnotexist")
-
+	config.C.TEMPLATE_REPO = "thistemplatedoesnotexist"
 	expectedRepoName := uuid.New().String()
 
 	if err := NewRepo(expectedRepoName, true, "expectedDescription"); err == nil {

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -6,78 +6,79 @@ import (
 	"testing"
 	"time"
 
-	"github.com/42-Short/shortinette/config"
 	"github.com/google/go-github/v66/github"
 	"github.com/google/uuid"
+	"github.com/joho/godotenv"
 )
 
-func cleanup(t *testing.T, repoName string) {
+var (
+	orga         string
+	token        string
+	templateRepo string
+)
+
+func TestMain(m *testing.M) {
+	_ = godotenv.Load("../.env")
+
+	orga = os.Getenv("ORGA_GITHUB")
+	token = os.Getenv("TOKEN_GITHUB")
+	templateRepo = os.Getenv("TEMPLATE_REPO")
+	m.Run()
+}
+
+func cleanup(t *testing.T, gh *GithubService, repoName string) {
 	if err := os.RemoveAll(repoName); err != nil {
 		t.Fatalf("cleanup failed: %v", err)
 	}
-	if err := deleteRepo(repoName); err != nil {
+	if err := gh.deleteRepo(repoName); err != nil {
 		t.Fatalf("cleanup failed: %v", err)
 	}
 }
 
 func TestNewRepoNonExistingOrga(t *testing.T) {
+	gh := NewGithubService(token, "thisorgadoesnoteist")
 	repoName := uuid.New().String()
 
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
-	orgaName := config.C.ORGA_GITHUB
-	config.C.ORGA_GITHUB = "thisorgadoesnoteist"
-	defer func(orgaName string) {
-		config.C.ORGA_GITHUB = orgaName
-	}(orgaName)
-
-	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}
 }
 
 func TestNewRepoMissinTemplateRepoEnvironmentVariable(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	orgaName := config.C.ORGA_GITHUB
-	config.C.ORGA_GITHUB = ""
-	defer func(orgaName string) {
-		config.C.ORGA_GITHUB = orgaName
-	}(orgaName)
-
-	if err := NewRepo(repoName, true, "this should not be created"); err == nil {
+	if err := gh.NewRepo("", repoName, true, "this should not be created"); err == nil {
 		t.Fatalf("missing environment variables should throw an error")
 	}
 }
 
 func TestNewRepoNonExistingTemplate(t *testing.T) {
-	templateRepoName := config.C.TEMPLATE_REPO
-	config.C.TEMPLATE_REPO = "thistemplatedoesnotexist"
-	defer func(templateRepoName string) {
-		config.C.TEMPLATE_REPO = templateRepoName
-	}(templateRepoName)
-
+	gh := NewGithubService(token, orga)
 	expectedRepoName := uuid.New().String()
 
-	if err := NewRepo(expectedRepoName, true, "expectedDescription"); err == nil {
+	if err := gh.NewRepo("thistemplatedoesnotexist", expectedRepoName, true, "expectedDescription"); err == nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
 }
 
 func TestNewRepoStandardFunctionality(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
 
-	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
+	if err := gh.NewRepo(templateRepo, expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
-	defer cleanup(t, expectedRepoName)
+	defer cleanup(t, gh, expectedRepoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
-	repo, _, err := client.Repositories.Get(context.Background(), config.C.ORGA_GITHUB, expectedRepoName)
+	client := github.NewClient(nil).WithAuthToken(token)
+	repo, _, err := client.Repositories.Get(context.Background(), orga, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify repo creation: %v", err)
 	}
@@ -94,82 +95,87 @@ func TestNewRepoStandardFunctionality(t *testing.T) {
 }
 
 func TestNewRepoAlreadyExisting(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	expectedRepoName := uuid.New().String()
 	expectedPrivate := true
 	expectedDescription := "description"
 
-	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
+	if err := gh.NewRepo(templateRepo, expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
-	defer cleanup(t, expectedRepoName)
+	defer cleanup(t, gh, expectedRepoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := NewRepo(expectedRepoName, expectedPrivate, expectedDescription); err != nil {
+	if err := gh.NewRepo(templateRepo, expectedRepoName, expectedPrivate, expectedDescription); err != nil {
 		t.Fatalf("NewRepo should not error on already exsiting repos: %v", err)
 	}
 }
 
 func TestAddCollaboratorNonExistingUser(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "idc"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "idc"); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := AddCollaborator("repo", "ireallydonotthinkthatthisgithubuserexists", "read"); err == nil {
+	if err := gh.AddCollaborator("repo", "ireallydonotthinkthatthisgithubuserexists", "read"); err == nil {
 		t.Fatalf("non-existing user should throw an error")
 	}
 }
 
 func TestAddCollaboratorNonExistingPermission(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "idc"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "idc"); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := AddCollaborator("repo", "winstonallo", "fornicate"); err == nil {
+	if err := gh.AddCollaborator("repo", "winstonallo", "fornicate"); err == nil {
 		t.Fatalf("non-existing permission level should throw an error")
 	}
 }
 
 func TestUploadFilesNonExistingFiles(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(repoName, "don't mind me just breaking code", "main", false, "foo", "bar"); err == nil {
+	if err := gh.UploadFiles(repoName, "don't mind me just breaking code", "main", false, "foo", "bar"); err == nil {
 		t.Fatalf("trying to upload non-existing files to a repo should throw an error")
 	}
 }
 
 func TestUploadFilesNormalFunctionality(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(repoName, "don't mind me just breaking code", "main", false, "git.go", "git_test.go"); err != nil {
+	if err := gh.UploadFiles(repoName, "don't mind me just breaking code", "main", false, "git.go", "git_test.go"); err != nil {
 		t.Fatalf("uploading an existing file should work, something went wrong: %v", err)
 	}
 
-	if err := Clone(repoName); err != nil {
+	if err := gh.Clone(repoName); err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
 
@@ -191,35 +197,37 @@ func TestUploadFilesNormalFunctionality(t *testing.T) {
 }
 
 func TestUploadFilesNonExistingBranch(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(repoName, "don't mind me just breaking code", "thisbranchdoesnotexist", false, "git.go", "git_test.go"); err == nil {
+	if err := gh.UploadFiles(repoName, "don't mind me just breaking code", "thisbranchdoesnotexist", false, "git.go", "git_test.go"); err == nil {
 		t.Fatalf("UploadFiles should return an error when trying to push to unexisting branch")
 	}
 }
 
 func TestUploadFilesNonDefaultBranch(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "this will be deleted soon_GITHUB"); err != nil {
+	if err := gh.NewRepo(templateRepo, repoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(repoName, "don't mind me just breaking code", "thisbranchshouldbecreated", true, "git.go", "git_test.go"); err != nil {
+	if err := gh.UploadFiles(repoName, "don't mind me just breaking code", "thisbranchshouldbecreated", true, "git.go", "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles should be able to create a new branch when needed")
 	}
 
-	if err := Clone(repoName); err != nil {
+	if err := gh.Clone(repoName); err != nil {
 		t.Fatalf("could not verify file upload: %v", err)
 	}
 
@@ -241,29 +249,30 @@ func TestUploadFilesNonDefaultBranch(t *testing.T) {
 }
 
 func TestNewReleaseNormalFunctionality(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	expectedRepoName := uuid.New().String()
 	expectedTagName := "tag"
 	expectedReleaseName := "release"
 	expectedBody := "body"
 
-	if err := NewRepo(expectedRepoName, true, "this will be deleted soon"); err != nil {
+	if err := gh.NewRepo(templateRepo, expectedRepoName, true, "this will be deleted soon"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
-	defer cleanup(t, expectedRepoName)
+	defer cleanup(t, gh, expectedRepoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
+	if err := gh.UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
-	if err := NewRelease(expectedRepoName, expectedTagName, expectedReleaseName, expectedBody); err != nil {
+	if err := gh.NewRelease(expectedRepoName, expectedTagName, expectedReleaseName, expectedBody); err != nil {
 		t.Fatalf("NewRelease returned an error on a standard use case: %v", err)
 	}
 
-	client := github.NewClient(nil).WithAuthToken(config.C.TOKEN_GITHUB)
+	client := github.NewClient(nil).WithAuthToken(token)
 
-	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), config.C.ORGA_GITHUB, expectedRepoName)
+	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), orga, expectedRepoName)
 	if err != nil {
 		t.Fatalf("could not verify release update: %v", err)
 	}
@@ -280,37 +289,39 @@ func TestNewReleaseNormalFunctionality(t *testing.T) {
 }
 
 func TestNewReleaseAlreadyExisting(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	expectedRepoName := uuid.New().String()
 
-	if err := NewRepo(expectedRepoName, true, "this will be deleted soon_GITHUB"); err != nil {
+	if err := gh.NewRepo(templateRepo, expectedRepoName, true, "this will be deleted soon_GITHUB"); err != nil {
 		t.Fatalf("could not create test repo: %v", err)
 	}
-	defer cleanup(t, expectedRepoName)
+	defer cleanup(t, gh, expectedRepoName)
 
 	time.Sleep(5 * time.Second) // Generating templates takes a few seconds
 
-	if err := UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
+	if err := gh.UploadFiles(expectedRepoName, "initial commit", "main", false, "git_test.go"); err != nil {
 		t.Fatalf("UploadFiles returned an error on initial commit: %v", err)
 	}
 
-	if err := NewRelease(expectedRepoName, "tag", "release", "body"); err != nil {
+	if err := gh.NewRelease(expectedRepoName, "tag", "release", "body"); err != nil {
 		t.Fatalf("NewRelease returned an error on a standard use case: %v", err)
 	}
 
-	if err := NewRelease(expectedRepoName, "tag", "release", "body"); err == nil {
+	if err := gh.NewRelease(expectedRepoName, "tag", "release", "body"); err == nil {
 		t.Fatalf("duplicate tag names should return an error")
 	}
 }
 
 func TestNewReleaseNonExistingrepo(t *testing.T) {
+	gh := NewGithubService(token, orga)
 	repoName := uuid.New().String()
 
-	if err := NewRepo(repoName, true, "idc"); err != nil {
+	if err := gh.NewRepo(os.Getenv("TEMPLATE_REPO"), repoName, true, "idc"); err != nil {
 		t.Fatalf("NewRepo returned an error on a standard use case: %v", err)
 	}
-	defer cleanup(t, repoName)
+	defer cleanup(t, gh, repoName)
 
-	if err := NewRelease("thisrepodoesnotexist", "tag", "release", "body"); err == nil {
+	if err := gh.NewRelease("thisrepodoesnotexist", "tag", "release", "body"); err == nil {
 		t.Fatalf("NewRelease did not return any error when trying to add a release to a non-existing repo")
 	}
 }

--- a/app/git/git_test.go
+++ b/app/git/git_test.go
@@ -25,7 +25,8 @@ func TestMain(m *testing.M) {
 	orga = os.Getenv("ORGA_GITHUB")
 	token = os.Getenv("TOKEN_GITHUB")
 	templateRepo = os.Getenv("TEMPLATE_REPO")
-	m.Run()
+	code := m.Run()
+	os.Exit(code)
 }
 
 func cleanup(t *testing.T, gh *GithubService, repoName string) {

--- a/app/main.go
+++ b/app/main.go
@@ -1,34 +1,4 @@
 package main
 
-import (
-	"net/http"
-
-	"github.com/42-Short/shortinette/tester"
-	"github.com/42-Short/shortinette/logger"
-	"github.com/gin-gonic/gin"
-)
-
-func helloWorld(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "Hello, World!"})
-}
-
-func router() (router *gin.Engine) {
-	router = gin.Default()
-
-	router.GET("/admin", helloWorld)
-
-	return router
-}
-
 func main() {
-	done := make(chan bool, 1)
-
-	tester.HandleSignals(done, true)
-	r := router()
-	if err := r.Run("0.0.0.0:5000"); err != nil {
-		logger.Error.Printf("error running gin server: %v", err)
-	}
-	done <- true
-
-	<-done
 }


### PR DESCRIPTION
- created a config struct which holds the metadata of the short (env variables, modules, participants)
- When you include the package the env get loaded and the env variables get initialised. -> panics if a variable is missing
    - The modules will get initialised in the short package as they will be passed as parameter to create a new short.
    -  The participants also will get loaded in the new short function as it is required for testing purpose to set wrong config paths so it cant be done in the init function
  
 - I decided to make the config global as we need it in several places. This should be fine as we will initialise everything in the short package and we only read from the config afterwards
 
 - The modules and participants will also get bulk inserted into the DB after creating a new short