### PR TITLE
feat(config,tester): support glob patterns for allowed files

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/42-Short/shortinette/logger"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/joho/godotenv"
 )
 
@@ -103,6 +104,13 @@ func NewExercise(executablePath string, score int, allowedFiles []string, turnIn
 	if allowedFiles == nil || len(allowedFiles) < 1 {
 		return nil, fmt.Errorf("at least one allowed file required")
 	}
+
+	for _, globPattern := range allowedFiles {
+		if !doublestar.ValidatePattern(globPattern) {
+			return nil, fmt.Errorf("allowedFiles contains an invalid glob pattern: %s", globPattern)
+		}
+	}
+
 	if score < 0 {
 		return nil, fmt.Errorf("score cannot be negative")
 	}

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -66,6 +66,18 @@ func TestNewExerciseNilAllowedFiles(t *testing.T) {
 	}
 }
 
+func TestNewExerciseAllowedFilesWithInvalidGlobPattern(t *testing.T) {
+	if _, err := NewExercise("foo", 10, []string{"/foo/[]*.go"}, "bar"); err == nil {
+		t.Fatalf("allowedFiles contains an invalid glob pattern")
+	}
+}
+
+func TestNewExerciseAllowedFiles(t *testing.T) {
+	if _, err := NewExercise("foo", 10, []string{"/foo/*.go", "ok.go"}, "bar"); err != nil {
+		t.Fatalf("allowedFiles contains valid files")
+	}
+}
+
 func TestNewExerciseNegativeScore(t *testing.T) {
 	if _, err := NewExercise("foo", -10, []string{"bar"}, "bar"); err == nil {
 		t.Fatalf("it should not be possible to initialize an exercise with negative score")

--- a/app/go.mod
+++ b/app/go.mod
@@ -6,6 +6,7 @@ require github.com/gin-gonic/gin v1.10.0
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,6 +1,8 @@
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
+github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=


### PR DESCRIPTION
Using `doublestar` as a dependency, since the standard library does not support recursive patterns (`**/*.rs`)