### PR TITLE
feat(short/rust): default implemnations to `Testable` mainly for covenience & add `Cargo` struct

### DIFF
--- a/rust/tester/Cargo.lock
+++ b/rust/tester/Cargo.lock
@@ -9,8 +9,341 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "libc"
+version = "0.2.167"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "tester"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs_extra",
+ "rand",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/rust/tester/Cargo.toml
+++ b/rust/tester/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.94"
+fs_extra = "1.3.0"
+rand = "0.8.5"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
+tempfile = "3.14.0"

--- a/rust/tester/src/cargo.rs
+++ b/rust/tester/src/cargo.rs
@@ -1,0 +1,151 @@
+use std::{
+    fs,
+    io::{self, BufRead, Write},
+    path, process,
+};
+
+pub struct Cargo {
+    dir: tempfile::TempDir,
+}
+
+impl Cargo {
+    pub fn new(name: &str) -> Self {
+        let dir = tempfile::tempdir().expect("Failed to create directory for cargo project");
+
+        let init_output = process::Command::new("cargo")
+            .arg("init")
+            .arg(dir.path())
+            .args(["--name", name])
+            .output()
+            .expect("Failed to execute cargo command");
+
+        assert!(
+            init_output.status.success(),
+            "Failed to cargo init a new project"
+        );
+
+        Self { dir }
+    }
+
+    pub fn copy_from(path: &path::PathBuf) -> Self {
+        let dir = tempfile::tempdir().expect("Failed to create directory for cargo project");
+
+        fs_extra::dir::copy(
+            path,
+            dir.path(),
+            &fs_extra::dir::CopyOptions::new().content_only(true),
+        )
+        .expect("Failed to copy content of cargo project");
+
+        // Just to go sure
+        _ = fs::remove_dir(dir.path().join("target"));
+
+        Self { dir }
+    }
+
+    pub fn compile(&self) -> Result<path::PathBuf, ()> {
+        let compile_output = process::Command::new("cargo")
+            .current_dir(self.dir.path())
+            .arg("build")
+            .arg("--release")
+            .arg("--message-format=json")
+            .output()
+            .expect("Failed to execute cargo build");
+
+        if !compile_output.status.success() {
+            return Err(());
+        }
+
+        let reader = io::BufReader::new(compile_output.stdout.as_slice());
+
+        #[derive(Debug, serde::Deserialize)]
+        struct CompilerOutput {
+            reason: String,
+            executable: String,
+        }
+
+        let executable_path = reader
+            .lines()
+            .map_while(Result::ok)
+            .map(|line| serde_json::from_str::<CompilerOutput>(&line))
+            .filter_map(Result::ok)
+            .filter(|output| output.reason.as_str() == "compiler-artifact")
+            .last()
+            .map(|output| path::PathBuf::from(output.executable))
+            .expect("Failed to get path to compiled exercise");
+
+        Ok(executable_path)
+    }
+
+    pub fn run_test<'a>(
+        &self,
+        test_filter: impl IntoIterator<Item = &'a str>,
+    ) -> Result<(), String> {
+        let test_output = process::Command::new("cargo")
+            .current_dir(self.dir.path())
+            .arg("test")
+            .args(test_filter)
+            .output()
+            .expect("Failed to execute cargo test");
+
+        if test_output.status.success() {
+            return Ok(());
+        };
+
+        let test_log = String::from_utf8_lossy(&test_output.stdout);
+
+        Err(test_log.into_owned())
+    }
+
+    pub fn check_clippy(&self, config: &str) -> bool {
+        let config_file_path = self.dir.path().join("clippy.toml");
+        let mut config_file =
+            fs::File::create(&config_file_path).expect("Failed to create clippy.toml file");
+
+        config_file
+            .write_all(config.as_bytes())
+            .expect("Failed to write clippy.toml file");
+
+        let clippy_output = process::Command::new("cargo")
+            .current_dir(self.dir.path())
+            .arg("clippy")
+            .arg("--")
+            .arg("-D")
+            .arg("warnings")
+            .output()
+            .expect("Failed to execute cargo clippy");
+
+        _ = fs::remove_file(config_file_path);
+
+        clippy_output.status.success()
+    }
+
+    pub fn test_list(&self, test_filter: &[&str]) -> Vec<String> {
+        let test_list_output = process::Command::new("cargo")
+            .current_dir(self.dir.path())
+            .arg("test")
+            .args(test_filter)
+            .arg("--")
+            .arg("--list")
+            // `--format=json` is a nightly feature...
+            .arg("--format=terse")
+            .output()
+            .expect("Failed to execute cargo test --list");
+
+        assert!(
+            test_list_output.status.success(),
+            "cargo test --list failed"
+        );
+
+        let out = String::from_utf8_lossy(&test_list_output.stdout);
+
+        out.lines()
+            .map(|line| {
+                &line[..line
+                    .rfind(": test")
+                    .expect("Test list is not correctly formatted")]
+            })
+            .map(String::from)
+            .collect()
+    }
+}

--- a/rust/tester/src/main.rs
+++ b/rust/tester/src/main.rs
@@ -1,8 +1,9 @@
-use std::env;
+use std::{env, path};
 
 use module::Module;
 use result::TestResult;
 
+mod cargo;
 mod module;
 mod result;
 mod testable;
@@ -32,4 +33,15 @@ fn main() -> TestResult {
     };
 
     module.run_test()
+}
+
+fn repository_path() -> path::PathBuf {
+    let repository_path = env::var("REPOSITORY")
+        .map(|path| path::PathBuf::from(&path))
+        .unwrap_or_else(|_| env::current_dir().expect("Failed to access cwd"));
+
+    // Assert is fine here since the tester should only be run on valid directories
+    assert!(repository_path.exists(), "Repository path does not exist");
+
+    repository_path
 }

--- a/rust/tester/src/module00/exercise00/mod.rs
+++ b/rust/tester/src/module00/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module00/exercise01/mod.rs
+++ b/rust/tester/src/module00/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module00/exercise02/mod.rs
+++ b/rust/tester/src/module00/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module00/exercise03/mod.rs
+++ b/rust/tester/src/module00/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module00/exercise04/mod.rs
+++ b/rust/tester/src/module00/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module00/exercise05/mod.rs
+++ b/rust/tester/src/module00/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module00/exercise06/mod.rs
+++ b/rust/tester/src/module00/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module00/exercise07/mod.rs
+++ b/rust/tester/src/module00/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module00/mod.rs
+++ b/rust/tester/src/module00/mod.rs
@@ -7,7 +7,9 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use std::path;
+
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module00 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module01/exercise00/mod.rs
+++ b/rust/tester/src/module01/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module01/exercise01/mod.rs
+++ b/rust/tester/src/module01/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module01/exercise02/mod.rs
+++ b/rust/tester/src/module01/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module01/exercise03/mod.rs
+++ b/rust/tester/src/module01/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module01/exercise04/mod.rs
+++ b/rust/tester/src/module01/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module01/exercise05/mod.rs
+++ b/rust/tester/src/module01/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module01/exercise06/mod.rs
+++ b/rust/tester/src/module01/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module01/exercise07/mod.rs
+++ b/rust/tester/src/module01/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module01/mod.rs
+++ b/rust/tester/src/module01/mod.rs
@@ -1,3 +1,5 @@
+use std::path;
+
 use exercise00::Exercise00;
 use exercise01::Exercise01;
 use exercise02::Exercise02;
@@ -7,7 +9,7 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module01 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module02/exercise00/mod.rs
+++ b/rust/tester/src/module02/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module02/exercise01/mod.rs
+++ b/rust/tester/src/module02/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module02/exercise02/mod.rs
+++ b/rust/tester/src/module02/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module02/exercise03/mod.rs
+++ b/rust/tester/src/module02/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module02/exercise04/mod.rs
+++ b/rust/tester/src/module02/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module02/exercise05/mod.rs
+++ b/rust/tester/src/module02/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module02/exercise06/mod.rs
+++ b/rust/tester/src/module02/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module02/exercise07/mod.rs
+++ b/rust/tester/src/module02/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module02/mod.rs
+++ b/rust/tester/src/module02/mod.rs
@@ -1,3 +1,5 @@
+use std::path;
+
 use exercise00::Exercise00;
 use exercise01::Exercise01;
 use exercise02::Exercise02;
@@ -7,7 +9,7 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module02 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module03/exercise00/mod.rs
+++ b/rust/tester/src/module03/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module03/exercise01/mod.rs
+++ b/rust/tester/src/module03/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module03/exercise02/mod.rs
+++ b/rust/tester/src/module03/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module03/exercise03/mod.rs
+++ b/rust/tester/src/module03/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module03/exercise04/mod.rs
+++ b/rust/tester/src/module03/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module03/exercise05/mod.rs
+++ b/rust/tester/src/module03/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module03/exercise06/mod.rs
+++ b/rust/tester/src/module03/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module03/exercise07/mod.rs
+++ b/rust/tester/src/module03/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module03/mod.rs
+++ b/rust/tester/src/module03/mod.rs
@@ -7,7 +7,9 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use std::path;
+
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module03 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module04/exercise00/mod.rs
+++ b/rust/tester/src/module04/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module04/exercise01/mod.rs
+++ b/rust/tester/src/module04/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module04/exercise02/mod.rs
+++ b/rust/tester/src/module04/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module04/exercise03/mod.rs
+++ b/rust/tester/src/module04/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module04/exercise04/mod.rs
+++ b/rust/tester/src/module04/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module04/exercise05/mod.rs
+++ b/rust/tester/src/module04/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module04/exercise06/mod.rs
+++ b/rust/tester/src/module04/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module04/exercise07/mod.rs
+++ b/rust/tester/src/module04/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module04/mod.rs
+++ b/rust/tester/src/module04/mod.rs
@@ -1,3 +1,5 @@
+use std::path;
+
 use exercise00::Exercise00;
 use exercise01::Exercise01;
 use exercise02::Exercise02;
@@ -7,7 +9,7 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module04 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module05/exercise00/mod.rs
+++ b/rust/tester/src/module05/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module05/exercise01/mod.rs
+++ b/rust/tester/src/module05/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module05/exercise02/mod.rs
+++ b/rust/tester/src/module05/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module05/exercise03/mod.rs
+++ b/rust/tester/src/module05/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module05/exercise04/mod.rs
+++ b/rust/tester/src/module05/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module05/exercise05/mod.rs
+++ b/rust/tester/src/module05/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module05/exercise06/mod.rs
+++ b/rust/tester/src/module05/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module05/exercise07/mod.rs
+++ b/rust/tester/src/module05/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module05/mod.rs
+++ b/rust/tester/src/module05/mod.rs
@@ -7,7 +7,9 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use std::path;
+
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +62,10 @@ impl Testable for Module05 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/module06/exercise00/mod.rs
+++ b/rust/tester/src/module06/exercise00/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
 
 impl Testable for Exercise00 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex00")
     }
 }

--- a/rust/tester/src/module06/exercise01/mod.rs
+++ b/rust/tester/src/module06/exercise01/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
 
 impl Testable for Exercise01 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex01")
     }
 }

--- a/rust/tester/src/module06/exercise02/mod.rs
+++ b/rust/tester/src/module06/exercise02/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise02;
 
 impl Testable for Exercise02 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex02")
     }
 }

--- a/rust/tester/src/module06/exercise03/mod.rs
+++ b/rust/tester/src/module06/exercise03/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
 impl Testable for Exercise03 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex03")
     }
 }

--- a/rust/tester/src/module06/exercise04/mod.rs
+++ b/rust/tester/src/module06/exercise04/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
 impl Testable for Exercise04 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex04")
     }
 }

--- a/rust/tester/src/module06/exercise05/mod.rs
+++ b/rust/tester/src/module06/exercise05/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
 
 impl Testable for Exercise05 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex05")
     }
 }

--- a/rust/tester/src/module06/exercise06/mod.rs
+++ b/rust/tester/src/module06/exercise06/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
 impl Testable for Exercise06 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex06")
     }
 }

--- a/rust/tester/src/module06/exercise07/mod.rs
+++ b/rust/tester/src/module06/exercise07/mod.rs
@@ -1,10 +1,12 @@
-use crate::{testable::Testable, result::TestResult};
+use std::path;
+
+use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise07;
 
 impl Testable for Exercise07 {
-    fn run_test(&self) -> TestResult {
-        todo!()
+    fn path(&self) -> path::PathBuf {
+        repository_path().join("ex07")
     }
 }

--- a/rust/tester/src/module06/mod.rs
+++ b/rust/tester/src/module06/mod.rs
@@ -7,7 +7,7 @@ use exercise05::Exercise05;
 use exercise06::Exercise06;
 use exercise07::Exercise07;
 
-use crate::{result::TestResult, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 mod exercise00;
 mod exercise01;
@@ -60,6 +60,10 @@ impl Testable for Module06 {
             Self::Ex06(exercise) => exercise.run_test(),
             Self::Ex07(exercise) => exercise.run_test(),
         }
+    }
+
+    fn path(&self) -> std::path::PathBuf {
+        repository_path()
     }
 }
 

--- a/rust/tester/src/testable.rs
+++ b/rust/tester/src/testable.rs
@@ -1,5 +1,86 @@
-use crate::result::TestResult;
+use std::path;
+
+use rand::seq::SliceRandom;
+
+use crate::{cargo::Cargo, result::TestResult};
 
 pub trait Testable {
-    fn run_test(&self) -> TestResult;
+    fn run_test(&self) -> TestResult {
+        if !self.check_clippy() {
+            eprintln!("`cargo clippy -- -D warnings` failed");
+
+            return TestResult::CompilationError;
+        }
+
+        if self.compile().is_err() {
+            eprintln!("Failed to compile");
+
+            return TestResult::CompilationError;
+        }
+
+        if let Err(test_output) = self.run_cargo_tests() {
+            eprintln!("{test_output}");
+
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
+    }
+
+    fn run_cargo_tests(&self) -> Result<(), String> {
+        let mut cargo_test_list = self.get_cargo().test_list(&["shortinette_tests"]);
+        assert!(!cargo_test_list.is_empty(), "No shortinette tests found");
+
+        // We do not want to create a new Cargo project for every test
+        let cargo = self.get_cargo();
+
+        let mut rng = rand::thread_rng();
+        cargo_test_list.shuffle(&mut rng);
+
+        let mut failed_output = Vec::new();
+        for test in cargo_test_list {
+            let Err(test_output) = cargo.run_test([test.as_str()]) else {
+                continue;
+            };
+
+            failed_output.push(test_output);
+        }
+
+        if failed_output.is_empty() {
+            Ok(())
+        } else {
+            Err(failed_output.join("\n"))
+        }
+    }
+
+    fn path(&self) -> path::PathBuf;
+
+    fn ensure_path(&self) -> path::PathBuf {
+        let path = self.path();
+
+        // Assert is fine here, since the tester will only be run on existing folders
+        assert!(path.exists(), "Folder does not exist");
+
+        path
+    }
+
+    fn compile(&self) -> Result<path::PathBuf, TestResult> {
+        Cargo::copy_from(&self.ensure_path())
+            .compile()
+            .map_err(|_| TestResult::CompilationError)
+    }
+
+    fn clippy_config(&self) -> &'static str {
+        include_str!("./default-clippy-rules.toml")
+    }
+
+    fn check_clippy(&self) -> bool {
+        let config = self.clippy_config();
+
+        self.get_cargo().check_clippy(config)
+    }
+
+    fn get_cargo(&self) -> Cargo {
+        Cargo::copy_from(&self.ensure_path())
+    }
 }


### PR DESCRIPTION
Currently the `Testable` does not support copying test files. Instead the tests have to be located directly in the exercise and the test module has to be called `shortinette_tests`.

This PR is based on `ifaoji/feat/rust-tester-skeleton`