### PR TITLE
feat(short/rust): add test library support

### DIFF
--- a/rust/tester/src/default-cargo-test.rs
+++ b/rust/tester/src/default-cargo-test.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod shortinette_tests {
+    #[test]
+    fn default() {
+        assert_eq!("Are the tests implemented?", "No.");
+    }
+}


### PR DESCRIPTION
Adding a default implementation for running tests.
1. Create a new cargo lib which will contain the shortinette test rust module.
2. Add the exercise as a dependency to the test lib.
3. Copy the shortinette test module tot the test lib.
4. Run the tests in the test lib in a random order.

Each `impl Testable for Exercise` can now overwrite the default implementation of `cargo_test_mod`, which will then be written to the test libs `src/lib.rs`:
```rs
fn cargo_test_mod(&self) -> &'static str {
    include_str!("./shortinette_tests.rs")
}
```