### PR TITLE
fix(short/rust/subjects/04): Use readers/writers instead of reading from stdin/writing to stdout

### DIFF
--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -106,7 +106,7 @@ lint to silence warnings about unused variables, functions, etc.
  Tests (when not specifically required by the subject) can use the symbols you want, even if
 they are not specified in the `allowed symbols` section. **However**, tests should **not** introduce **any additional external dependencies** beyond those already required by the subject.
 
-## Exercise 00: Wait thats it?
+## Exercise 00: Wait that's it?
 
 ```txt
 turn-in directories:

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -176,7 +176,7 @@ Write a **function** that copies `input`, to `writer` and all filenames provided
 Your function must have the following signature:
 
 ```rust
-pub fn tee<R: std::io::Read, W: std::io::Write>(input: R, writer: &mut W, filenames: &[String]);
+pub fn tee<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, filenames: &[String]);
 ```
 
 Example:

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -185,7 +185,7 @@ Example:
 ```rust
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    tee(&mut std::io::stdin(), &mut std::io::stdout().lock(), args);
+    tee(&mut std::io::stdin(), &mut std::io::stdout(), &args);
 }
 ```
 
@@ -273,7 +273,7 @@ Example Usage:
 
 ```rust
 fn main() {
-    pipeline(&mut std::io::stdin(), &mut std::io::stdout(), vec![String::from("echo"), String::from("-n")]);
+    pipeline(&mut std::io::stdin(), &mut std::io::stdout(), &[String::from("echo"), String::from("-n")]);
 }
 ```
 Expected Output:
@@ -322,13 +322,12 @@ Example Usage:
 
 ```rust
 fn main() {
-    let command_lines = vec![
-        vec![String::from("echo"), String::from("a"), String::from("b")],
-        vec![String::from("sleep"), String::from("1")],
-        vec![String::from("cat"), String::from("Cargo.toml")],
-    ];
+    let cli1 = &[String::from("echo"), String::from("a"), String::from("b")];
+    let cli2 = &[String::from("sleep"), String::from("1")];
+    let cli3 = &[String::from("cat"), String::from("Cargo.toml")];
+    let command_lines = vec![cli1, cli2, cli3];
 
-    multiplexer(&mut std::io::stdout(), command_lines);
+    multiplexer(&mut std::io::stdout(), &command_lines);
 }
 ```
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -215,7 +215,7 @@ allowed symbols:
     std::{print, println, eprintln}
 ```
 
-Create a **function** that computes the total size of a directory or file. Once computed, write the size followed by a newline, and formatted like in the examples below.
+Create a **function** that computes the total size of a directory or file. Once computed, write the size followed by a newline to `writer`, formatted like in the examples below.
 
 Your function must have the following signature:
 ```rust

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -119,7 +119,7 @@ allowed symbols:
     none
 ```
 
-Create `Outcome` and `Maybe` which should mimic `Result` and `Option` so that test compiles and runs
+Create `Outcome` and `Maybe` which should mimic `Result` and `Option` so below test compiles and runs. For this exercise, you are exceptionally (_and obviously_) **not** allowed to use the `Option` and `Result` types.
 
 ```rust
 #[cfg(test)]

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -299,8 +299,7 @@ allowed symbols:
     std::iter::*
     std::process::{Command, Stdio, Child}
     std::vec::Vec
-    std::io::{stdout, Write, Read}
-    std::{write, writeln}
+    std::io::Write
     std::eprintln
 ```
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -185,7 +185,7 @@ Example:
 ```rust
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    tee(std::io::stdin(), &mut std::io::stdout().lock(), &args);
+    tee(&mut std::io::stdin(), &mut std::io::stdout().lock(), &args);
 }
 ```
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -416,7 +416,7 @@ allowed symbols:
 
 Create a **function** with the following signature:
 ```rust
-pub fn strings<W: std::io::Write>(writer: &mut W, path: &str, z: bool, m: bool, M: bool);
+pub fn strings<W: std::io::Write>(writer: &mut W, path: &str, z: bool, min: Option<usize>, max: Option<usize>);
 ```
 
 It must read an arbitrary binary file and write printable UTF-8 strings it finds into `writer`.
@@ -429,7 +429,7 @@ $ echo 'int main() { return 0; }' > test.c && cc test.c
 
 ```rust
 fn main() {
-    strings(&mut std::io::stdout, "./a.out", false, false, false);
+    strings(&mut std::io::stdout, "./a.out", false, None, None);
 }
 ```
 
@@ -451,11 +451,11 @@ ELF
 
 * A *printable UTF-8 string* is only composed of non-control characters.
 
-The function must have the following options, passed to it as booleans:
+The function must have the following options, passed to it as arguments:
 
-* `-z` filters out strings that are not null-terminated.
-* `-m <min>` filters out strings that are strictly smaller than `min`.
-* `-M <max>` filters out strings that are strictly larger than `max`.
+* `z` filters out strings that are not null-terminated.
+* `min` filters out strings that are strictly smaller than `min`.
+* `max` filters out strings that are strictly larger than `max`.
 
 Your function must never panic when interacting with the file system. Handle errors properly.
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -177,7 +177,7 @@ Write a **function** that copies `input` to `writer` and all filenames provided 
 Your function must have the following signature:
 
 ```rust
-pub fn tee<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, filenames: Vec<String>);
+pub fn tee<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, filenames: &[String]);
 ```
 
 Example:
@@ -263,7 +263,7 @@ allowed symbols:
 Create a **function** with the following signature:
 
 ```rust
-pub fn pipeline<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, args: Vec<String>);
+pub fn pipeline<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, args: &[String]);
 ```
 
 It must spawn a process using the path (`args[0]`, arguments (`args[1..]`)), and input (`input`) passed as arguments,
@@ -307,7 +307,7 @@ allowed symbols:
 Create a **function** with the following signature:
 
 ```rust
-pub fn multiplexer<W: std::io::Write>(writer: &mut W, command_lines: Vec<Vec<String>>);
+pub fn multiplexer<W: std::io::Write>(writer: &mut W, command_lines: &[&[String]]);
 ```
 
 It must start multiple command lines passed as arguments, and write each of them followed by its output to `stdout`, separated by empty lines, to `writer`. 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -226,7 +226,7 @@ Example Usage:
 
 ```rust
 fn main() {
-    let arg: String = std::env::args().nth(1);
+    let arg: String = std::env::args().nth(1).unwrap();
     duh(&mut std::io::stdout(), &arg);
 }
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -185,7 +185,7 @@ Example:
 ```rust
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    tee(&mut std::io::stdin(), &mut std::io::stdout().lock(), &args);
+    tee(&mut std::io::stdin(), &mut std::io::stdout().lock(), args);
 }
 ```
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -159,7 +159,7 @@ turn-in directory:
     ex01/
 
 files to turn in:
-    src/main.rs  Cargo.toml
+    src/lib.rs  Cargo.toml
 
 allowed symbols:
     std::io::{Write, Read, stdin, stdout}
@@ -171,12 +171,24 @@ allowed symbols:
     std::{print, println, eprintln}
 ```
 
-Create a **program** that reads the standard input, and copies it to the standard output, as well as
-to every file specified in command-line arguments.
+Write a **function** that copies `input`, to `writer` and all filenames provided as arguments.
+
+Your function must have the following signature:
+
+```rust
+pub fn tee<R: std::io::Read, W: std::io::Write>(input: R, writer: &mut W, filenames: &[String]);
+```
 
 Example:
 
-```txt
+```rust
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    tee(std::io::stdin(), &mut std::io::stdout().lock(), &args);
+}
+```
+
+```plaintext
 >_ echo "Hello, World!" | cargo run -- a b c
 Hello, World!
 >_ cat a b c
@@ -185,8 +197,7 @@ Hello, World!
 Hello, World!
 ```
 
-You program must not panic when interacting with the file system. All errors must be handled
-properly. You are free to choose what to do in that case, but you must *not* crash/panic.
+You program must not panic when interacting with the file system. All errors must be handled properly. You are free to choose what to do in that case, but you must *not* crash/panic.
 
 ## Exercise 02: Duh
 

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -322,10 +322,10 @@ Example Usage:
 
 ```rust
 fn main() {
-    let cli1 = &[String::from("echo"), String::from("a"), String::from("b")];
-    let cli2 = &[String::from("sleep"), String::from("1")];
-    let cli3 = &[String::from("cat"), String::from("Cargo.toml")];
-    let command_lines = vec![cli1, cli2, cli3];
+        let cli1: &[String] = &[String::from("echo"), String::from("a"), String::from("b")];
+        let cli2: &[String] = &[String::from("sleep"), String::from("1")];
+        let cli3: &[String] = &[String::from("cat"), String::from("Cargo.toml")];
+        let command_lines = vec![cli1, cli2, cli3];
 
     multiplexer(&mut std::io::stdout(), &command_lines);
 }

--- a/rust/subjects/module-04.md
+++ b/rust/subjects/module-04.md
@@ -476,30 +476,21 @@ allowed dependencies:
 
 allowed symbols:
     std::vec::Vec
-    std::env::args
     std::io::{stdin, stdout, stderr, Write, Read}
     std::fs::File
     rand::*
     rug::*
 ```
 
-Write a **program** that behaves in the following way:
+Write a **library** with the 3 following functions:
 
-```sh
-# Generate key pair
->_ cargo run -- gen-keys my-key.pub my-key.priv
-
-# Encrypt a message
->_ << EOF cargo run -- encrypt my-key.pub > encrypted-message
-This is a very secret message.
-EOF
-
-# Decrypt a message
->_ cat encrypted-message | cargo run -- decrypt my-key.priv
-This is a very secret message.
+```rust
+pub fn gen_keys(pub_key_path: &str, priv_key_path: &str);
+pub fn encrypt<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, pub_key_path: &str);
+pub fn decrypt<R: std::io::Read, W: std::io::Write>(input: &mut R, writer: &mut W, priv_key_path: &str);
 ```
 
-### Key Generation
+### `gen_keys`
 
 In order to generate keys, your program must perform the following steps:
 
@@ -517,10 +508,10 @@ The resulting keys are:
 * Private key: `(D, M)`
 * Public key: `(E, M)`
 
-### Encryption & Decryption
+### `encrypt` and `decrypt`
 
 * Encryption: `encrypt(m) = m^E % M`
-* Encryption: `encrypt(m') = m'^D % M`
+* Decryption: `encrypt(m') = m'^D % M`
 
 For any `m < M`, `decrypt(encrypt(m)) == m` should hold true.
 


### PR DESCRIPTION
All exercises are now functions (`lib.rs`) and take readers/writers as arguments to ensure testability.