### PR TITLE
fix(short/rust): Add rand dependency to test projects

### DIFF
--- a/rust/tester/src/cargo.rs
+++ b/rust/tester/src/cargo.rs
@@ -91,12 +91,12 @@ impl Cargo {
     }
 
     pub fn add_dependency(&self, name: &str, version: &str) -> Result<(), ()> {
+        let dependency = format!("{}@{}", name, version);
+
         let add_output = process::Command::new("cargo")
             .current_dir(self.dir.path())
             .arg("add")
-            .arg(name)
-            .arg("--version")
-            .arg(version)
+            .arg(dependency)
             .output()
             .expect("Failed to execute cargo add");
 

--- a/rust/tester/src/testable.rs
+++ b/rust/tester/src/testable.rs
@@ -63,6 +63,10 @@ pub trait Testable {
             )
             .expect("Failed to add exercise as dependency to test project");
 
+        cargo
+            .add_dependency("rand", "0.8")
+            .expect("Failed to add rand as dependency to test project");
+
         let mut lib_file = fs::File::create(cargo.path().join("src/lib.rs"))
             .expect("Failed to open src/lib.rs of test module");
         lib_file


### PR DESCRIPTION
Rand needs to be added as dependency in the test projects as well, to make it usable by the shortinette tests.

I also fixed an issue in the `add_dependency` function, where the CLI arguments passed to `cargo add` were wrong (there is no `--version` argument).