### PR TITLE
feat(short/rust/tests/01)

### DIFF
--- a/rust/subjects/01/README.md
+++ b/rust/subjects/01/README.md
@@ -70,8 +70,8 @@ files to turn-in:
 Create two **functions**. Both must add two integers together.
 
 ```rust
-fn add(a: &i32, b: i32) -> i32;
-fn add_assign(a: &mut i32, b: i32);
+pub fn add(a: &i32, b: i32) -> i32;
+pub fn add_assign(a: &mut i32, b: i32);
 ```
 
 * `add` must return the result of the operation.
@@ -93,7 +93,7 @@ allowed symbols:
 Write a **function** that returns the smallest value among two numbers.
 
 ```rust
-fn min(a: &i32, b: &i32) -> &i32;
+pub fn min(a: &i32, b: &i32) -> &i32;
 ```
 
 * Note that you may have to add some *lifetime annotations* to the function in order to make it
@@ -117,7 +117,7 @@ allowed symbols:
 Create a **function** that maps three color components to a name.
 
 ```rust
-const fn color_name(color: &[u8; 3]) -> &str;
+pub const fn color_name(color: &[u8; 3]) -> &str;
 ```
 The `if` keyword is **_not_** allowed!
 
@@ -184,7 +184,7 @@ allowed symbols:
 Write a **function** that returns the first occurrence of `needle` in `haystack`.
 
 ```rust
-fn largest_group(haystack: &[u32], needle: &[u32]) -> &[u32];
+pub fn first_group(haystack: &[u32], needle: &[u32]) -> &[u32];
 ```
 
 * Note that you will need to add **lifetime annotations** to the function signature to ensure correct borrowing. The borrow checker must enforce that the resulting slice is borrowed from `haystack`, not from `needle`.
@@ -193,10 +193,10 @@ fn largest_group(haystack: &[u32], needle: &[u32]) -> &[u32];
 Example:
 
 ```rust
-assert_eq!(largest_group(&[1, 3, 4, 3, 5, 5, 4], &[1, 3]), &[1, 3]);
-assert_eq!(largest_group(&[1, 3, 4, 3, 5, 5, 4], &[5]), &[5]);
-assert_eq!(largest_group(&[1, 3, 4, 3, 5, 5, 4], &[6, 9]), &[]);
-assert_eq!(largest_group(&[1, 3, 4, 3, 5, 5, 4], &[4, 3]), &[4, 3]);
+assert_eq!(first_group(&[1, 3, 4, 3, 5, 5, 4], &[1, 3]), &[1, 3]);
+assert_eq!(first_group(&[1, 3, 4, 3, 5, 5, 4], &[5]), &[5]);
+assert_eq!(first_group(&[1, 3, 4, 3, 5, 5, 4], &[6, 9]), &[]);
+assert_eq!(first_group(&[1, 3, 4, 3, 5, 5, 4], &[4, 3]), &[4, 3]);
 ```
 This test must compile and run:
 ```rust
@@ -209,7 +209,7 @@ fn test_lifetimes() {
     {
         let needle = [2, 3];
         // The result should be a valid slice of haystack after needle has expired
-        result = largest_group(&haystack, &needle);
+        result = first_group(&haystack, &needle);
     }
     
     assert_eq!(result, &[2, 3]);
@@ -235,7 +235,7 @@ Write a function that sorts a list of boxes in such a way that each box can be "
 
 The function signature should look like this:
 ```rust
-fn sort_boxes(boxes: &mut [[u32; 2]]);
+pub fn sort_boxes(boxes: &mut [[u32; 2]]);
 ```
 
 The sorting should follow these criteria:
@@ -269,7 +269,7 @@ allowed symbols:
 Write a **function** that removes all repeated elements of a list, preserving its initial ordering.
 
 ```rust
-fn deduplicate(list: &mut Vec<i32>);
+pub fn deduplicate(list: &mut Vec<i32>);
 ```
 
 Example:
@@ -301,7 +301,7 @@ Write a **function** that adds two numbers together. The numbers are given as a 
 digits and may be arbitrarily large.
 
 ```rust
-fn big_add(a: &[u8], b: &[u8]) -> Vec<u8>;
+pub fn big_add(a: &[u8], b: &[u8]) -> Vec<u8>;
 ```
 
 * `a` and `b` must only contain digits (`b'0'` to `b'9'` included). If anything else is found, the
@@ -332,10 +332,10 @@ allowed symbols:
 Leonardo has `n` tasks, which he needs to prioritize. He organized them into a vector of tasks. One task is defined as follows:
 
 ```rust
-struct Task{
-    start_time: u32,
-    end_time: u32,
-    cookies: u32,
+pub struct Task{
+    pub start_time: u32,
+    pub end_time: u32,
+    pub cookies: u32,
 }
 ```
 
@@ -348,7 +348,7 @@ Unfortunately, he sucks at multitasking. Write a **function** which returns the 
 Your function must have this signature:
 
 ```rust
-fn time_manager(tasks: &mut Vec<Task>) -> u32
+pub fn time_manager(tasks: &mut Vec<Task>) -> u32
 ```
 
 **Constraints**

--- a/rust/subjects/01/README.md
+++ b/rust/subjects/01/README.md
@@ -128,19 +128,19 @@ The name of a color is determined using the following rules, applied in order. T
 
 `Legend: [red, green, blue]`
 
-* **"dark gray"**: Any color whose red, green, and blue components are all between 0 and 128 (inclusive) is "Dark Gray/Black".
+* **"dark gray"**: Any color whose red, green, and blue components are all between 0 and 127 (inclusive) is "Dark Gray/Black".
 
-* **"dark red"**: Any color whose red component is between 128 and 255 (inclusive), and whose green and blue components are both between 0 and 128 (inclusive), is "Dark Red".
+* **"dark red"**: Any color whose red component is between 128 and 255 (inclusive), and whose green and blue components are both between 0 and 127 (inclusive), is "Dark Red".
 
-* **"dark green"**: Any color whose green component is between 128 and 255 (inclusive), and whose red and blue components are both between 0 and 128 (inclusive), is "Dark Green".
+* **"dark green"**: Any color whose green component is between 128 and 255 (inclusive), and whose red and blue components are both between 0 and 127 (inclusive), is "Dark Green".
 
-* **"olive"**: Any color whose red and green components are both between 128 and 255 (inclusive), and whose blue component is between 0 and 128 (inclusive), is "Dark Yellow/Olive".
+* **"olive"**: Any color whose red and green components are both between 128 and 255 (inclusive), and whose blue component is between 0 and 127 (inclusive), is "Dark Yellow/Olive".
 
-* **"dark blue"**: Any color whose blue component is between 128 and 255 (inclusive), and whose red and green components are both between 0 and 128 (inclusive), is "Dark Blue".
+* **"dark blue"**: Any color whose blue component is between 128 and 255 (inclusive), and whose red and green components are both between 0 and 127 (inclusive), is "Dark Blue".
 
-* **"purple"**: Any color whose red and blue components are both between 128 and 255 (inclusive), and whose green component is between 0 and 128 (inclusive), is "Dark Magenta/Purple".
+* **"purple"**: Any color whose red and blue components are both between 128 and 255 (inclusive), and whose green component is between 0 and 127 (inclusive), is "Dark Magenta/Purple".
 
-* **"teal"**: Any color whose green and blue components are both between 128 and 255 (inclusive), and whose red component is between 0 and 128 (inclusive), is "Dark Cyan/Teal".
+* **"teal"**: Any color whose green and blue components are both between 128 and 255 (inclusive), and whose red component is between 0 and 127 (inclusive), is "Dark Cyan/Teal".
 
 * **"light gray"**: Any color whose red, green, and blue components are all between 128 and 255 (inclusive) is "Light Gray/White".
 
@@ -162,7 +162,7 @@ mod test {
             name_of_the_best_color = color_name(&the_best_color);
         }
 
-        assert_eq!(name_of_the_best_color, "dark grey");
+        assert_eq!(name_of_the_best_color, "dark gray");
     }
 }
 ```

--- a/rust/subjects/01/README.md
+++ b/rust/subjects/01/README.md
@@ -98,6 +98,7 @@ fn min(a: &i32, b: &i32) -> &i32;
 
 * Note that you may have to add some *lifetime annotations* to the function in order to make it
 compile.
+* If both numbers are equal, `b` should be returned
 * The `return` keyword is still disallowed.
 
 ## Exercise 02: Don't we all love darkmode?

--- a/rust/tester/src/module01/exercise00/mod.rs
+++ b/rust/tester/src/module01/exercise00/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise00 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex00")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise00/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise00/shortinette_tests.rs
@@ -10,14 +10,14 @@ mod shortinette_tests_0100 {
         let a: i32 = rng.gen_range(1..=100);
         let b: i32 = rng.gen_range(1..=100);
 
-        assert_eq!(add(&a, b), a + b);
+        assert_eq!(add(&a, b), a + b, "Failed for ({}, {})", a, b);
     }
 
     #[test]
     fn test_add_2() {
         let a = i32::MAX;
 
-        assert_eq!(add(&a, 0), i32::MAX);
+        assert_eq!(add(&a, 0), i32::MAX, "Failed for ({}, {})", a, 0);
     }
 
     #[test]
@@ -27,7 +27,7 @@ mod shortinette_tests_0100 {
         let a = i32::MAX;
         let b = rng.gen_range(i32::MIN..0);
 
-        assert_eq!(add(&a, b), a + b);
+        assert_eq!(add(&a, b), a + b, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -37,7 +37,7 @@ mod shortinette_tests_0100 {
         let a = rng.gen_range(i32::MIN..0);
         let b = i32::MAX;
 
-        assert_eq!(add(&a, b), a + b);
+        assert_eq!(add(&a, b), a + b, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -50,7 +50,7 @@ mod shortinette_tests_0100 {
         let expected = a + b;
         add_assign(&mut a, b);
 
-        assert_eq!(a, expected);
+        assert_eq!(a, expected, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -58,7 +58,7 @@ mod shortinette_tests_0100 {
         let mut a = i32::MAX;
 
         add_assign(&mut a, 0);
-        assert_eq!(a, i32::MAX);
+        assert_eq!(a, i32::MAX, "Failed for ({}, {})", a, 0);
     }
 
     #[test]
@@ -71,7 +71,7 @@ mod shortinette_tests_0100 {
         let expected = a + b;
         add_assign(&mut a, b);
 
-        assert_eq!(a, expected);
+        assert_eq!(a, expected, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -84,6 +84,6 @@ mod shortinette_tests_0100 {
         let expected = a + b;
         add_assign(&mut a, b);
 
-        assert_eq!(a, expected);
+        assert_eq!(a, expected, "Failed for ({}, {})", a, b);
     }
 }

--- a/rust/tester/src/module01/exercise00/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise00/shortinette_tests.rs
@@ -1,0 +1,89 @@
+#[cfg(test)]
+mod shortinette_tests_0100 {
+    use ex00::{add, add_assign};
+    use rand::Rng;
+
+    #[test]
+    fn test_add_1() {
+        let mut rng = rand::thread_rng();
+
+        let a: i32 = rng.gen_range(1..=100);
+        let b: i32 = rng.gen_range(1..=100);
+
+        assert_eq!(add(&a, b), a + b);
+    }
+
+    #[test]
+    fn test_add_2() {
+        let a = i32::MAX;
+
+        assert_eq!(add(&a, 0), i32::MAX);
+    }
+
+    #[test]
+    fn test_add_3() {
+        let mut rng = rand::thread_rng();
+
+        let a = i32::MAX;
+        let b = rng.gen_range(i32::MIN..0);
+
+        assert_eq!(add(&a, b), a + b);
+    }
+
+    #[test]
+    fn test_add_4() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(i32::MIN..0);
+        let b = i32::MAX;
+
+        assert_eq!(add(&a, b), a + b);
+    }
+
+    #[test]
+    fn test_add_assign_1() {
+        let mut rng = rand::thread_rng();
+
+        let mut a: i32 = rng.gen_range(1..=100);
+        let b: i32 = rng.gen_range(1..=100);
+
+        let expected = a + b;
+        add_assign(&mut a, b);
+
+        assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn test_add_assign_2() {
+        let mut a = i32::MAX;
+
+        add_assign(&mut a, 0);
+        assert_eq!(a, i32::MAX);
+    }
+
+    #[test]
+    fn test_add_assign_3() {
+        let mut rng = rand::thread_rng();
+
+        let mut a = i32::MAX;
+        let b = rng.gen_range(i32::MIN..0);
+
+        let expected = a + b;
+        add_assign(&mut a, b);
+
+        assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn test_add_assign_4() {
+        let mut rng = rand::thread_rng();
+
+        let mut a = rng.gen_range(i32::MIN..0);
+        let b = i32::MAX;
+
+        let expected = a + b;
+        add_assign(&mut a, b);
+
+        assert_eq!(a, expected);
+    }
+}

--- a/rust/tester/src/module01/exercise01/mod.rs
+++ b/rust/tester/src/module01/exercise01/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise01 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex01")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise01/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise01/shortinette_tests.rs
@@ -1,0 +1,77 @@
+#[cfg(test)]
+mod shortinette_tests_0101 {
+    use ex01::min;
+    use rand::Rng;
+
+    #[test]
+    fn test_1() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(1..=100);
+        let b = a + 1;
+
+        assert_eq!(min(&a, &b), &a);
+    }
+
+    #[test]
+    fn test_2() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(1..=100);
+        let b = a - 1;
+
+        assert_eq!(min(&a, &b), &b);
+    }
+
+    #[test]
+    fn test_equal() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(1..=100);
+        let b = a;
+
+        assert!(std::ptr::eq(min(&a, &b), &b));
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(i32::MIN..0);
+        let b = rng.gen_range(i32::MIN..0);
+
+        let expected = if b <= a { &b } else { &a };
+
+        assert_eq!(min(&a, &b), expected);
+    }
+
+    #[test]
+    fn test_i32_min() {
+        let mut rng = rand::thread_rng();
+
+        let mut a = i32::MIN;
+        let mut b = rng.gen_range(i32::MIN + 1..=i32::MAX);
+
+        if rng.gen_range(0..=1) == 0 {
+            std::mem::swap(&mut a, &mut b);
+        }
+
+        let expected = if b <= a { &b } else { &a };
+
+        assert_eq!(min(&a, &b), &a);
+    }
+
+    #[test]
+    fn test_i32_max() {
+        let mut rng = rand::thread_rng();
+
+        let mut a = rng.gen_range(i32::MIN..i32::MAX);
+        let mut b = i32::MAX;
+
+        if rng.gen_range(0..=1) == 0 {
+            std::mem::swap(&mut a, &mut b);
+        }
+
+        assert_eq!(min(&a, &b), &a);
+    }
+}

--- a/rust/tester/src/module01/exercise01/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise01/shortinette_tests.rs
@@ -10,7 +10,7 @@ mod shortinette_tests_0101 {
         let a = rng.gen_range(1..=100);
         let b = a + 1;
 
-        assert_eq!(min(&a, &b), &a);
+        assert_eq!(min(&a, &b), &a, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -20,7 +20,7 @@ mod shortinette_tests_0101 {
         let a = rng.gen_range(1..=100);
         let b = a - 1;
 
-        assert_eq!(min(&a, &b), &b);
+        assert_eq!(min(&a, &b), &b, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -30,7 +30,7 @@ mod shortinette_tests_0101 {
         let a = rng.gen_range(1..=100);
         let b = a;
 
-        assert!(std::ptr::eq(min(&a, &b), &b));
+        assert!(std::ptr::eq(min(&a, &b), &b), "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -42,7 +42,7 @@ mod shortinette_tests_0101 {
 
         let expected = if b <= a { &b } else { &a };
 
-        assert_eq!(min(&a, &b), expected);
+        assert_eq!(min(&a, &b), expected, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -58,7 +58,7 @@ mod shortinette_tests_0101 {
 
         let expected = if b <= a { &b } else { &a };
 
-        assert_eq!(min(&a, &b), &a);
+        assert_eq!(min(&a, &b), expected, "Failed for ({}, {})", a, b);
     }
 
     #[test]
@@ -72,6 +72,8 @@ mod shortinette_tests_0101 {
             std::mem::swap(&mut a, &mut b);
         }
 
-        assert_eq!(min(&a, &b), &a);
+        let expected = if b <= a { &b } else { &a };
+
+        assert_eq!(min(&a, &b), expected, "Failed for ({}, {})", a, b);
     }
 }

--- a/rust/tester/src/module01/exercise02/mod.rs
+++ b/rust/tester/src/module01/exercise02/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise02 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex02")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise02/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise02/shortinette_tests.rs
@@ -1,0 +1,161 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0102 {
+    use ex02::color_name;
+    use rand::Rng;
+
+    #[test]
+    fn test_lifetimes() {
+        let name_of_the_best_color;
+
+        {
+            let the_best_color = [42, 42, 42];
+            name_of_the_best_color = color_name(&the_best_color);
+        }
+
+        assert_eq!(name_of_the_best_color, "dark gray");
+    }
+
+    #[test]
+    fn test_dark_gray_1() {
+        let color = color_name(&[127, 127, 127]);
+        assert_eq!(color, "dark gray");
+    }
+
+    #[test]
+    fn test_dark_gray_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(0..128),
+            rng.gen_range(0..128),
+            rng.gen_range(0..128),
+        ]);
+        assert_eq!(color, "dark gray");
+    }
+
+    #[test]
+    fn test_dark_red_1() {
+        let color = color_name(&[128, 127, 127]);
+        assert_eq!(color, "dark red");
+    }
+
+    #[test]
+    fn test_dark_red_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(128..=255),
+            rng.gen_range(0..128),
+            rng.gen_range(0..128),
+        ]);
+        assert_eq!(color, "dark red");
+    }
+
+    #[test]
+    fn test_dark_green_1() {
+        let color = color_name(&[127, 128, 127]);
+        assert_eq!(color, "dark green");
+    }
+
+    #[test]
+    fn test_dark_green_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(0..128),
+            rng.gen_range(128..=255),
+            rng.gen_range(0..128),
+        ]);
+        assert_eq!(color, "dark green");
+    }
+
+    #[test]
+    fn test_olive_1() {
+        let color = color_name(&[128, 128, 127]);
+        assert_eq!(color, "olive");
+    }
+
+    #[test]
+    fn test_olive_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(128..=255),
+            rng.gen_range(128..=255),
+            rng.gen_range(0..128),
+        ]);
+        assert_eq!(color, "olive");
+    }
+
+    #[test]
+    fn test_dark_blue_1() {
+        let color = color_name(&[127, 127, 128]);
+        assert_eq!(color, "dark blue");
+    }
+
+    #[test]
+    fn test_dark_blue_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(0..128),
+            rng.gen_range(0..128),
+            rng.gen_range(128..=255),
+        ]);
+        assert_eq!(color, "dark blue");
+    }
+
+    #[test]
+    fn test_purple_1() {
+        let color = color_name(&[128, 127, 128]);
+        assert_eq!(color, "purple");
+    }
+
+    #[test]
+    fn test_purple_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(128..=255),
+            rng.gen_range(0..128),
+            rng.gen_range(128..=255),
+        ]);
+        assert_eq!(color, "purple");
+    }
+
+    #[test]
+    fn test_teal_1() {
+        let color = color_name(&[127, 128, 128]);
+        assert_eq!(color, "teal");
+    }
+
+    #[test]
+    fn test_teal_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(0..128),
+            rng.gen_range(128..=255),
+            rng.gen_range(128..=255),
+        ]);
+        assert_eq!(color, "teal");
+    }
+
+    #[test]
+    fn test_light_gray_1() {
+        let color = color_name(&[128, 128, 128]);
+        assert_eq!(color, "light gray");
+    }
+
+    #[test]
+    fn test_light_gray_2() {
+        let mut rng = rand::thread_rng();
+
+        let color = color_name(&[
+            rng.gen_range(128..=255),
+            rng.gen_range(128..=255),
+            rng.gen_range(128..=255),
+        ]);
+        assert_eq!(color, "light gray");
+    }
+}

--- a/rust/tester/src/module01/exercise02/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise02/shortinette_tests.rs
@@ -12,150 +12,169 @@ mod shortinette_tests_rust_0102 {
             name_of_the_best_color = color_name(&the_best_color);
         }
 
-        assert_eq!(name_of_the_best_color, "dark gray");
+        assert_eq!(
+            name_of_the_best_color, "dark gray",
+            "Failed for [42, 42, 42]"
+        );
     }
 
     #[test]
     fn test_dark_gray_1() {
-        let color = color_name(&[127, 127, 127]);
-        assert_eq!(color, "dark gray");
+        let input = [127, 127, 127];
+        let color = color_name(&input);
+        assert_eq!(color, "dark gray", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_gray_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(0..128),
             rng.gen_range(0..128),
             rng.gen_range(0..128),
-        ]);
-        assert_eq!(color, "dark gray");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "dark gray", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_red_1() {
-        let color = color_name(&[128, 127, 127]);
-        assert_eq!(color, "dark red");
+        let input = [128, 127, 127];
+        let color = color_name(&input);
+        assert_eq!(color, "dark red", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_red_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(128..=255),
             rng.gen_range(0..128),
             rng.gen_range(0..128),
-        ]);
-        assert_eq!(color, "dark red");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "dark red", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_green_1() {
-        let color = color_name(&[127, 128, 127]);
-        assert_eq!(color, "dark green");
+        let input = [127, 128, 127];
+        let color = color_name(&input);
+        assert_eq!(color, "dark green", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_green_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(0..128),
             rng.gen_range(128..=255),
             rng.gen_range(0..128),
-        ]);
-        assert_eq!(color, "dark green");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "dark green", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_olive_1() {
-        let color = color_name(&[128, 128, 127]);
-        assert_eq!(color, "olive");
+        let input = [128, 128, 127];
+        let color = color_name(&input);
+        assert_eq!(color, "olive", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_olive_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(128..=255),
             rng.gen_range(128..=255),
             rng.gen_range(0..128),
-        ]);
-        assert_eq!(color, "olive");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "olive", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_blue_1() {
-        let color = color_name(&[127, 127, 128]);
-        assert_eq!(color, "dark blue");
+        let input = [127, 127, 128];
+        let color = color_name(&input);
+        assert_eq!(color, "dark blue", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_dark_blue_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(0..128),
             rng.gen_range(0..128),
             rng.gen_range(128..=255),
-        ]);
-        assert_eq!(color, "dark blue");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "dark blue", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_purple_1() {
-        let color = color_name(&[128, 127, 128]);
-        assert_eq!(color, "purple");
+        let input = [128, 127, 128];
+        let color = color_name(&input);
+        assert_eq!(color, "purple", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_purple_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(128..=255),
             rng.gen_range(0..128),
             rng.gen_range(128..=255),
-        ]);
-        assert_eq!(color, "purple");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "purple", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_teal_1() {
-        let color = color_name(&[127, 128, 128]);
-        assert_eq!(color, "teal");
+        let input = [127, 128, 128];
+        let color = color_name(&input);
+        assert_eq!(color, "teal", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_teal_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(0..128),
             rng.gen_range(128..=255),
             rng.gen_range(128..=255),
-        ]);
-        assert_eq!(color, "teal");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "teal", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_light_gray_1() {
-        let color = color_name(&[128, 128, 128]);
-        assert_eq!(color, "light gray");
+        let input = [128, 128, 128];
+        let color = color_name(&input);
+        assert_eq!(color, "light gray", "Failed for {:?}", input);
     }
 
     #[test]
     fn test_light_gray_2() {
         let mut rng = rand::thread_rng();
 
-        let color = color_name(&[
+        let input = [
             rng.gen_range(128..=255),
             rng.gen_range(128..=255),
             rng.gen_range(128..=255),
-        ]);
-        assert_eq!(color, "light gray");
+        ];
+        let color = color_name(&input);
+        assert_eq!(color, "light gray", "Failed for {:?}", input);
     }
 }

--- a/rust/tester/src/module01/exercise03/mod.rs
+++ b/rust/tester/src/module01/exercise03/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise03 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex03")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise03/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise03/shortinette_tests.rs
@@ -1,0 +1,252 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0103 {
+    use ex03::first_group;
+    use rand::Rng;
+
+    #[test]
+    fn test_lifetimes() {
+        let haystack = [1, 2, 3, 2, 1];
+        let result;
+
+        {
+            let needle = [2, 3];
+            result = first_group(&haystack, &needle);
+        }
+
+        assert_eq!(result, &[2, 3]);
+    }
+
+    #[test]
+    fn test_both_empty() {
+        assert_eq!(
+            first_group(&[], &[]),
+            &[],
+            "Empty slice expected when both haystack and needle are empty."
+        );
+    }
+
+    #[test]
+    fn test_needle_empty() {
+        let mut rng = rand::thread_rng();
+
+        let haystack: [u32; 1] = [rng.gen_range(0..=u32::MAX)];
+        assert_eq!(
+            first_group(&haystack, &[]),
+            &[],
+            "Empty slice expected when needle is empty."
+        );
+    }
+
+    #[test]
+    fn test_haystack_empty() {
+        let mut rng = rand::thread_rng();
+
+        let needle: [u32; 1] = [rng.gen_range(0..=u32::MAX)];
+        assert_eq!(
+            first_group(&[], &needle),
+            &[],
+            "Empty slice expected when haystack is empty."
+        );
+    }
+
+    #[test]
+    fn test_match_at_start() {
+        let mut rng = rand::thread_rng();
+
+        let needle_length = rng.gen_range(5..15);
+        let needle: Vec<u32> = (0..needle_length)
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+        let mut haystack = needle.clone();
+
+        for _ in 0..rng.gen_range(10..100) {
+            haystack.push(rng.gen_range(0..=u32::MAX));
+        }
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &haystack[0..needle_length],
+            "Invalid result with match at the start of the haystack."
+        );
+    }
+
+    #[test]
+    fn test_match_at_end() {
+        let mut rng = rand::thread_rng();
+
+        let needle_length = rng.gen_range(5..15);
+        let needle: Vec<u32> = (0..needle_length)
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut haystack: Vec<u32> = (0..rng.gen_range(10..100))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+        haystack.extend(&needle);
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &haystack[haystack.len() - needle_length..],
+            "Invalid result with match at the end of the haystack."
+        );
+    }
+
+    #[test]
+    fn test_match_in_middle() {
+        let mut rng = rand::thread_rng();
+
+        let needle_length = rng.gen_range(5..15);
+        let needle: Vec<u32> = (0..needle_length)
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut haystack: Vec<u32> = (0..rng.gen_range(5..50))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+        let startpos = haystack.len();
+        haystack.extend(&needle);
+
+        for _ in 0..rng.gen_range(5..50) {
+            haystack.push(rng.gen_range(0..=u32::MAX));
+        }
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &haystack[startpos..startpos + needle_length],
+            "Invalid result with match in the middle of the haystack."
+        );
+    }
+
+    #[test]
+    fn test_match_short_needle() {
+        let mut rng = rand::thread_rng();
+
+        let haystack: Vec<u32> = (0..rng.gen_range(10..100))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut needle_pos;
+        loop {
+            needle_pos = rng.gen_range(0..haystack.len());
+            let needle = haystack[needle_pos];
+
+            // Ensure that the item we are searching for doesn't exist multiple times
+            // There is already another test that checks for multiple matches
+            if haystack.iter().filter(|&&item| item == needle).count() == 1 {
+                break;
+            }
+        }
+        let needle = [haystack[needle_pos]];
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &[haystack[needle_pos]],
+            "Invalid result if the needle consists of only one element."
+        );
+    }
+
+    #[test]
+    fn test_multiple_matches() {
+        let mut rng = rand::thread_rng();
+
+        let needle_length = rng.gen_range(5..15);
+        let needle: Vec<u32> = (0..needle_length)
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut haystack: Vec<u32> = (0..rng.gen_range(5..50))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let startpos = haystack.len();
+        haystack.extend(&needle);
+
+        for _ in 0..rng.gen_range(5..50) {
+            haystack.push(rng.gen_range(0..=u32::MAX));
+        }
+
+        haystack.extend(&needle);
+        for _ in 0..rng.gen_range(5..50) {
+            haystack.push(rng.gen_range(0..=u32::MAX));
+        }
+
+        assert!(
+            std::ptr::eq(
+                first_group(&haystack, &needle),
+                &haystack[startpos..startpos + needle_length]
+            ),
+            "Function didn't return the first match in haystack when there were multiple matches"
+        );
+    }
+
+    #[test]
+    fn test_needle_longer_than_haystack() {
+        let mut rng = rand::thread_rng();
+
+        let haystack: Vec<u32> = (0..rng.gen_range(10..100))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let needle: Vec<u32> = haystack
+            .iter()
+            .copied()
+            .chain(std::iter::once(rng.gen_range(0..=u32::MAX)))
+            .collect();
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &[],
+            "Expected empty slice when needle is longer than haystack."
+        );
+    }
+
+    #[test]
+    fn test_no_match() {
+        let mut rng = rand::thread_rng();
+
+        let haystack: Vec<u32> = (0..rng.gen_range(10..100))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut needle_val;
+        loop {
+            needle_val = rng.gen_range(0..=u32::MAX);
+
+            // Ensure item doesn't exist
+            if haystack.iter().all(|&item| item != needle_val) {
+                break;
+            }
+        }
+        let needle = [needle_val];
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &[],
+            "Expected empty slice when item from needle is not present in haystack."
+        );
+    }
+
+    #[test]
+    fn test_needle_wrong_order() {
+        let mut rng = rand::thread_rng();
+
+        let haystack: Vec<u32> = (0..rng.gen_range(10..100))
+            .map(|_| rng.gen_range(0..=u32::MAX))
+            .collect();
+
+        let mut needle: Vec<u32>;
+        // What are the chances that the haystack is the same if you reverse it
+        loop {
+            needle = haystack.iter().rev().copied().collect();
+            if haystack != needle {
+                break;
+            }
+        }
+
+        assert_eq!(
+            first_group(&haystack, &needle),
+            &[],
+            "Expected empty slice when all items from the needle are present in haystack, but the order is wrong."
+        );
+    }
+}

--- a/rust/tester/src/module01/exercise04/mod.rs
+++ b/rust/tester/src/module01/exercise04/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise04 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex04")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise04/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise04/shortinette_tests.rs
@@ -1,0 +1,115 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0104 {
+    use ex04::sort_boxes;
+    use rand::prelude::SliceRandom;
+    use rand::Rng;
+    use std::collections::HashMap;
+
+    fn get_next_value(current: &[u32; 2]) -> [u32; 2] {
+        let mut rng = rand::thread_rng();
+
+        let width = current[0] + (rng.gen_range(0..10) > 4) as u32;
+        let height = current[1] + (rng.gen_range(0..10) > 4) as u32;
+
+        [width, height]
+    }
+
+    fn add_boxes_shuffle(boxes: &mut Vec<[u32; 2]>, amount: usize, sortable: bool) {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..amount {
+            let prev = boxes.last().unwrap();
+            boxes.push(get_next_value(prev));
+        }
+
+        if !sortable {
+            let position = rng.gen_range(0..boxes.len() - 2);
+            boxes[position + 1] = [boxes[position][0] + 1, boxes[position][1]];
+            boxes[position + 2] = [boxes[position][0], boxes[position][1] + 1];
+        }
+
+        boxes.shuffle(&mut rng);
+    }
+
+    // Using a HashMap to check if all the values returned by the function are the same
+    // as the original input, to avoid having the solution itself in the public repo.
+    fn is_sorted(boxes: &[[u32; 2]], initial: &[[u32; 2]]) -> bool {
+        let mut box_counter = HashMap::new();
+
+        for item in initial {
+            *box_counter.entry(item).or_insert(0) += 1;
+        }
+
+        for window in boxes.windows(2) {
+            if let [a, b] = window {
+                if b[0] > a[0] || b[1] > a[1] {
+                    return false;
+                }
+            }
+        }
+
+        for item in boxes {
+            if let Some(count) = box_counter.get_mut(item) {
+                *count -= 1;
+                if *count == 0 {
+                    box_counter.remove(item);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        box_counter.is_empty()
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut boxes = [];
+        sort_boxes(&mut boxes);
+        assert!(boxes.is_empty(), "Failed for an empty list as input");
+    }
+
+    #[test]
+    fn test_regular() {
+        let mut boxes = vec![[1, 2]];
+        add_boxes_shuffle(&mut boxes, 100, true);
+        let initial = boxes.clone();
+
+        let original_str = format!("{:?}", boxes);
+        sort_boxes(&mut boxes);
+        assert_eq!(
+            is_sorted(&boxes, &initial),
+            true,
+            "Boxes haven't been sorted correctly\nInput: {}\nAfter Sorting: {:?}",
+            original_str,
+            boxes
+        );
+    }
+
+    #[test]
+    fn test_0_0_box() {
+        let mut boxes = vec![[0, 0]];
+        add_boxes_shuffle(&mut boxes, 100, true);
+        let initial = boxes.clone();
+
+        let original_str = format!("{:?}", boxes);
+        sort_boxes(&mut boxes);
+        assert_eq!(
+            is_sorted(&boxes, &initial),
+            true,
+            "Boxes haven't been sorted correctly\nInput: {}\nAfter Sorting: {:?}",
+            original_str,
+            boxes
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unsortable() {
+        let mut boxes = vec![[1, 2]];
+        add_boxes_shuffle(&mut boxes, 100, false);
+
+        let original_str = format!("{:?}", boxes);
+        sort_boxes(&mut boxes);
+    }
+}

--- a/rust/tester/src/module01/exercise05/mod.rs
+++ b/rust/tester/src/module01/exercise05/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise05 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex05")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise05/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise05/shortinette_tests.rs
@@ -1,0 +1,70 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0105 {
+    use ex05::deduplicate;
+    use rand::Rng;
+
+    fn check_deduplicated(input: &[i32], deduplicated: &[i32]) -> bool {
+        let mut input_vec = Vec::new();
+        let mut deduplicated_vec = Vec::new();
+
+        for nbr in input {
+            if !input_vec.contains(&nbr) {
+                input_vec.push(nbr);
+            }
+        }
+
+        for nbr in deduplicated {
+            if !deduplicated_vec.contains(&nbr) {
+                deduplicated_vec.push(nbr);
+            } else {
+                return false;
+            }
+        }
+
+        input_vec == deduplicated_vec
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut v = vec![];
+        deduplicate(&mut v);
+        assert_eq!(v, [], "Error with empty vec as input");
+    }
+
+    #[test]
+    fn test_subject() {
+        let mut v = vec![1, 2, 2, 3, 2, 4, 3];
+        deduplicate(&mut v);
+        assert_eq!(v, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_only_duplicates() {
+        let mut rng = rand::thread_rng();
+
+        let value = rng.gen_range(i32::MIN..=i32::MAX);
+        let mut v: Vec<i32> = (0..100).map(|_| value).collect();
+        deduplicate(&mut v);
+        assert_eq!(
+            v,
+            [value],
+            "Error with vec which only contains the same value",
+        );
+    }
+
+    #[test]
+    fn test_mixed() {
+        let mut rng = rand::thread_rng();
+
+        let mut v: Vec<i32> = (0..1000).map(|_| rng.gen_range(-100..=100)).collect();
+        let input = v.clone();
+
+        deduplicate(&mut v);
+        assert!(
+            check_deduplicated(&input, &v),
+            "Incorrect result\nInput: {:?}\nOutput: {:?}",
+            input,
+            v
+        );
+    }
+}

--- a/rust/tester/src/module01/exercise06/mod.rs
+++ b/rust/tester/src/module01/exercise06/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise06 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex06")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise06/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise06/shortinette_tests.rs
@@ -1,0 +1,218 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0106 {
+    use ex06::big_add;
+    use rand::Rng;
+
+    #[test]
+    #[should_panic]
+    fn test_both_empty() {
+        big_add(b"", b"");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_a_empty() {
+        let mut rng = rand::thread_rng();
+
+        let number: Vec<u8> = (0..5).map(|_| rng.gen_range(0..10)).collect();
+        big_add(b"", &number);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_b_empty() {
+        let mut rng = rand::thread_rng();
+
+        let number: Vec<u8> = (0..5).map(|_| rng.gen_range(0..10)).collect();
+        big_add(&number, b"");
+    }
+
+    fn format_characters(characters: &[u8]) -> String {
+        let mut output = String::from("\"");
+
+        for &char in characters {
+            if char.is_ascii_graphic() || char.is_ascii_whitespace() {
+                output.push(char as char);
+            } else {
+                output.push_str(&format!("\\{}", char));
+            }
+        }
+        output.push('"');
+        output
+    }
+
+    fn big_add_wrapper(a: &[u8], b: &[u8]) {
+        let result = std::panic::catch_unwind(|| {
+            big_add(a, b);
+        });
+        match result {
+            Ok(_) => panic!(
+                "Invalid input not correctly handled\nInput: {} + {}",
+                format_characters(a),
+                format_characters(b)
+            ),
+            Err(payload) => {
+                let payload_str = match payload.downcast_ref::<String>() {
+                    Some(s) => s.as_str(),
+                    None => match payload.downcast_ref::<&str>() {
+                        Some(s) => s,
+                        None => return,
+                    },
+                };
+                if payload_str.contains("subtract with overflow") {
+                    panic!(
+                        "Invalid input not correctly handled\nInput: {} + {}",
+                        format_characters(a),
+                        format_characters(b)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_bytes() {
+        let mut rng = rand::thread_rng();
+        let test_chars = ['/', ':', ' ', '+', '-', '\0'];
+        let mut input_strings = Vec::new();
+
+        for character in test_chars {
+            let number: Vec<u8> = (0..5).map(|_| rng.gen_range(b'0'..=b'9')).collect();
+
+            let mut prefixed = vec![character as u8];
+            prefixed.extend(&number);
+
+            let mut appended = number.clone();
+            appended.push(character as u8);
+
+            input_strings.push(prefixed);
+            input_strings.push(appended);
+        }
+
+        for input in &input_strings {
+            let validnbr: Vec<u8> = (0..5).map(|_| rng.gen_range(b'0'..=b'9')).collect();
+            big_add_wrapper(&validnbr, input);
+            big_add_wrapper(input, &validnbr);
+        }
+    }
+
+    // Subtract `a` from the received result and check if its equal to `b`, so I can check the result
+    // for randomized inputs without having the solution itself in the repo
+    fn big_sub(a: &[u8], b: &[u8], output: &[u8]) -> bool {
+        if !output.iter().all(|val| val.is_ascii_digit()) {
+            return false;
+        }
+
+        let mut result = Vec::new();
+        let mut rest = 0;
+        let max_len = output.len().max(a.len());
+        for i in 0..max_len {
+            let digit1 = if i < output.len() {
+                output[output.len() - 1 - i] - b'0'
+            } else {
+                0
+            };
+
+            let digit2 = if i < a.len() {
+                a[a.len() - 1 - i] - b'0'
+            } else {
+                0
+            };
+
+            let mut diff = digit1 as i8 + rest as i8 - digit2 as i8;
+            if diff < 0 {
+                diff += 10;
+                rest = -1;
+            } else {
+                rest = 0;
+            }
+
+            result.insert(0, diff as u8 + b'0');
+        }
+
+        while result.len() > 1 && result[0] == b'0' {
+            result.remove(0);
+        }
+
+        let mut b = b.to_vec();
+        while b.len() > 1 && b[0] == b'0' {
+            b.remove(0);
+        }
+
+        result == b
+    }
+
+    #[test]
+    fn test_only_zeros() {
+        let mut rng = rand::thread_rng();
+
+        let number1: Vec<u8> = (0..rng.gen_range(5..15)).map(|_| b'0').collect();
+        let number2: Vec<u8> = (0..rng.gen_range(5..15)).map(|_| b'0').collect();
+
+        assert_eq!(
+            big_add(&number1, &number2),
+            b"0",
+            "Failed for ({}, {})",
+            format_characters(&number1),
+            format_characters(&number2)
+        );
+    }
+
+    #[test]
+    fn test_leading_zeros() {
+        let mut rng = rand::thread_rng();
+
+        let number1: Vec<u8> = (0..rng.gen_range(5..15)).map(|_| b'0').collect();
+        let mut number2: Vec<u8> = (0..rng.gen_range(5..15)).map(|_| b'0').collect();
+        let additional = rng.gen_range(b'0'..=b'9');
+        number2.push(additional);
+
+        assert_eq!(
+            big_add(&number1, &number2),
+            &[additional],
+            "Failed for ({}, {})",
+            format_characters(&number1),
+            format_characters(&number2)
+        );
+    }
+
+    #[test]
+    fn test_short_numbers() {
+        let mut rng = rand::thread_rng();
+
+        let number1: Vec<u8> = (0..rng.gen_range(1..5))
+            .map(|_| rng.gen_range(b'0'..=b'9'))
+            .collect();
+        let number2: Vec<u8> = (0..rng.gen_range(1..5))
+            .map(|_| rng.gen_range(b'0'..=b'9'))
+            .collect();
+
+        let outcome = big_add(&number1, &number2);
+        assert!(
+            big_sub(&number1, &number2, &outcome),
+            "Failed for ({}, {})",
+            format_characters(&number1),
+            format_characters(&number2)
+        );
+    }
+
+    #[test]
+    fn test_long_numbers() {
+        let mut rng = rand::thread_rng();
+
+        let number1: Vec<u8> = (0..rng.gen_range(50..100))
+            .map(|_| rng.gen_range(b'0'..=b'9'))
+            .collect();
+        let number2: Vec<u8> = (0..rng.gen_range(50..100))
+            .map(|_| rng.gen_range(b'0'..=b'9'))
+            .collect();
+
+        let outcome = big_add(&number1, &number2);
+        assert!(
+            big_sub(&number1, &number2, &outcome),
+            "Failed for ({}, {})",
+            format_characters(&number1),
+            format_characters(&number2)
+        );
+    }
+}

--- a/rust/tester/src/module01/exercise07/mod.rs
+++ b/rust/tester/src/module01/exercise07/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise07 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex07")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module01/exercise07/shortinette_tests.rs
+++ b/rust/tester/src/module01/exercise07/shortinette_tests.rs
@@ -1,0 +1,800 @@
+#[cfg(test)]
+mod shortinette_tests_rust_0107 {
+    use ex07::time_manager;
+    use ex07::Task;
+    use rand::seq::SliceRandom;
+    use rand::Rng;
+    use std::fmt::{Display, Error, Formatter};
+
+    struct Testcase {
+        tasks: Vec<Task>,
+        expected: u32,
+    }
+
+    // This way we can put the input values in the trace, even if the participants don't add
+    // #[derive(Debug)] to the Task struct
+    impl Display for Testcase {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+            let strings: Vec<String> = self
+                .tasks
+                .iter()
+                .map(|task| {
+                    format!(
+                        "{{{}, {}, {}}}",
+                        task.start_time, task.end_time, task.cookies
+                    )
+                })
+                .collect();
+            write!(f, "{:?}", strings)
+        }
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut tasks = vec![];
+        assert_eq!(time_manager(&mut tasks), 0, "Failed for empty input.");
+    }
+
+    // Just multiplying all the input values and the expected output by a random value, to have
+    // kinda random inputs without having to have the solution in the public repo.
+    // Also shuffling so the order changes.
+    fn scale_tests(testcase: &mut Testcase) {
+        let mut rng = rand::thread_rng();
+
+        let multiplicator = rng.gen_range(1..100);
+        for task in testcase.tasks.iter_mut() {
+            task.start_time *= multiplicator;
+            task.end_time *= multiplicator;
+            task.cookies *= multiplicator;
+        }
+        testcase.expected *= multiplicator;
+        testcase.tasks.shuffle(&mut rng);
+    }
+
+    #[test]
+    fn test_0() {
+        let tasks = vec![
+            Task {
+                start_time: 0,
+                end_time: 3,
+                cookies: 10,
+            },
+            Task {
+                start_time: 4,
+                end_time: 5,
+                cookies: 5,
+            },
+            Task {
+                start_time: 6,
+                end_time: 10,
+                cookies: 25,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 40,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_1() {
+        let tasks = vec![
+            Task {
+                start_time: 0,
+                end_time: 3,
+                cookies: 10,
+            },
+            Task {
+                start_time: 3,
+                end_time: 5,
+                cookies: 5,
+            },
+            Task {
+                start_time: 5,
+                end_time: 10,
+                cookies: 25,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 40,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_2() {
+        let tasks = vec![
+            Task {
+                start_time: 0,
+                end_time: 5,
+                cookies: 10,
+            },
+            Task {
+                start_time: 3,
+                end_time: 7,
+                cookies: 5,
+            },
+            Task {
+                start_time: 5,
+                end_time: 10,
+                cookies: 25,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 35,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_4() {
+        let tasks = vec![
+            Task {
+                start_time: 0,
+                end_time: 5,
+                cookies: 1,
+            },
+            Task {
+                start_time: 3,
+                end_time: 7,
+                cookies: 30,
+            },
+            Task {
+                start_time: 5,
+                end_time: 10,
+                cookies: 25,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 30,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_5() {
+        let tasks = vec![
+            Task {
+                start_time: 0,
+                end_time: 5,
+                cookies: 1,
+            },
+            Task {
+                start_time: 3,
+                end_time: 7,
+                cookies: 24,
+            },
+            Task {
+                start_time: 5,
+                end_time: 10,
+                cookies: 25,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 26,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_6() {
+        let tasks = vec![
+            Task {
+                start_time: 2,
+                end_time: 25,
+                cookies: 10,
+            },
+            Task {
+                start_time: 1,
+                end_time: 22,
+                cookies: 23,
+            },
+            Task {
+                start_time: 6,
+                end_time: 19,
+                cookies: 22,
+            },
+            Task {
+                start_time: 6,
+                end_time: 16,
+                cookies: 24,
+            },
+            Task {
+                start_time: 2,
+                end_time: 7,
+                cookies: 12,
+            },
+            Task {
+                start_time: 19,
+                end_time: 20,
+                cookies: 20,
+            },
+            Task {
+                start_time: 16,
+                end_time: 18,
+                cookies: 23,
+            },
+            Task {
+                start_time: 4,
+                end_time: 6,
+                cookies: 17,
+            },
+            Task {
+                start_time: 12,
+                end_time: 13,
+                cookies: 14,
+            },
+            Task {
+                start_time: 12,
+                end_time: 15,
+                cookies: 23,
+            },
+        ];
+        let mut testcase = Testcase {
+            tasks,
+            expected: 84,
+        };
+        scale_tests(&mut testcase);
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+
+    #[test]
+    fn test_long() {
+        let tasks = vec![
+            Task {
+                start_time: 65,
+                end_time: 84,
+                cookies: 14,
+            },
+            Task {
+                start_time: 88,
+                end_time: 108,
+                cookies: 20,
+            },
+            Task {
+                start_time: 49,
+                end_time: 113,
+                cookies: 16,
+            },
+            Task {
+                start_time: 41,
+                end_time: 118,
+                cookies: 21,
+            },
+            Task {
+                start_time: 88,
+                end_time: 132,
+                cookies: 5,
+            },
+            Task {
+                start_time: 105,
+                end_time: 136,
+                cookies: 9,
+            },
+            Task {
+                start_time: 101,
+                end_time: 146,
+                cookies: 23,
+            },
+            Task {
+                start_time: 126,
+                end_time: 170,
+                cookies: 2,
+            },
+            Task {
+                start_time: 166,
+                end_time: 180,
+                cookies: 11,
+            },
+            Task {
+                start_time: 164,
+                end_time: 187,
+                cookies: 18,
+            },
+            Task {
+                start_time: 133,
+                end_time: 197,
+                cookies: 15,
+            },
+            Task {
+                start_time: 181,
+                end_time: 212,
+                cookies: 15,
+            },
+            Task {
+                start_time: 142,
+                end_time: 227,
+                cookies: 7,
+            },
+            Task {
+                start_time: 223,
+                end_time: 240,
+                cookies: 6,
+            },
+            Task {
+                start_time: 184,
+                end_time: 241,
+                cookies: 24,
+            },
+            Task {
+                start_time: 159,
+                end_time: 250,
+                cookies: 15,
+            },
+            Task {
+                start_time: 205,
+                end_time: 252,
+                cookies: 8,
+            },
+            Task {
+                start_time: 192,
+                end_time: 256,
+                cookies: 1,
+            },
+            Task {
+                start_time: 255,
+                end_time: 258,
+                cookies: 21,
+            },
+            Task {
+                start_time: 243,
+                end_time: 261,
+                cookies: 1,
+            },
+            Task {
+                start_time: 264,
+                end_time: 272,
+                cookies: 7,
+            },
+            Task {
+                start_time: 216,
+                end_time: 275,
+                cookies: 16,
+            },
+            Task {
+                start_time: 203,
+                end_time: 275,
+                cookies: 1,
+            },
+            Task {
+                start_time: 200,
+                end_time: 283,
+                cookies: 16,
+            },
+            Task {
+                start_time: 230,
+                end_time: 285,
+                cookies: 2,
+            },
+            Task {
+                start_time: 231,
+                end_time: 315,
+                cookies: 17,
+            },
+            Task {
+                start_time: 313,
+                end_time: 323,
+                cookies: 5,
+            },
+            Task {
+                start_time: 321,
+                end_time: 359,
+                cookies: 7,
+            },
+            Task {
+                start_time: 306,
+                end_time: 360,
+                cookies: 8,
+            },
+            Task {
+                start_time: 324,
+                end_time: 363,
+                cookies: 20,
+            },
+            Task {
+                start_time: 338,
+                end_time: 382,
+                cookies: 9,
+            },
+            Task {
+                start_time: 302,
+                end_time: 386,
+                cookies: 4,
+            },
+            Task {
+                start_time: 368,
+                end_time: 430,
+                cookies: 12,
+            },
+            Task {
+                start_time: 408,
+                end_time: 436,
+                cookies: 12,
+            },
+            Task {
+                start_time: 398,
+                end_time: 437,
+                cookies: 9,
+            },
+            Task {
+                start_time: 360,
+                end_time: 440,
+                cookies: 9,
+            },
+            Task {
+                start_time: 429,
+                end_time: 445,
+                cookies: 19,
+            },
+            Task {
+                start_time: 412,
+                end_time: 446,
+                cookies: 22,
+            },
+            Task {
+                start_time: 396,
+                end_time: 451,
+                cookies: 8,
+            },
+            Task {
+                start_time: 441,
+                end_time: 462,
+                cookies: 1,
+            },
+            Task {
+                start_time: 402,
+                end_time: 469,
+                cookies: 25,
+            },
+            Task {
+                start_time: 418,
+                end_time: 482,
+                cookies: 1,
+            },
+            Task {
+                start_time: 444,
+                end_time: 486,
+                cookies: 25,
+            },
+            Task {
+                start_time: 418,
+                end_time: 507,
+                cookies: 24,
+            },
+            Task {
+                start_time: 470,
+                end_time: 513,
+                cookies: 20,
+            },
+            Task {
+                start_time: 493,
+                end_time: 514,
+                cookies: 12,
+            },
+            Task {
+                start_time: 498,
+                end_time: 531,
+                cookies: 8,
+            },
+            Task {
+                start_time: 485,
+                end_time: 532,
+                cookies: 18,
+            },
+            Task {
+                start_time: 436,
+                end_time: 536,
+                cookies: 15,
+            },
+            Task {
+                start_time: 453,
+                end_time: 548,
+                cookies: 15,
+            },
+            Task {
+                start_time: 541,
+                end_time: 567,
+                cookies: 14,
+            },
+            Task {
+                start_time: 555,
+                end_time: 583,
+                cookies: 3,
+            },
+            Task {
+                start_time: 503,
+                end_time: 588,
+                cookies: 5,
+            },
+            Task {
+                start_time: 529,
+                end_time: 595,
+                cookies: 20,
+            },
+            Task {
+                start_time: 568,
+                end_time: 609,
+                cookies: 5,
+            },
+            Task {
+                start_time: 607,
+                end_time: 612,
+                cookies: 21,
+            },
+            Task {
+                start_time: 524,
+                end_time: 625,
+                cookies: 1,
+            },
+            Task {
+                start_time: 584,
+                end_time: 630,
+                cookies: 9,
+            },
+            Task {
+                start_time: 581,
+                end_time: 630,
+                cookies: 22,
+            },
+            Task {
+                start_time: 545,
+                end_time: 635,
+                cookies: 5,
+            },
+            Task {
+                start_time: 553,
+                end_time: 639,
+                cookies: 21,
+            },
+            Task {
+                start_time: 633,
+                end_time: 668,
+                cookies: 12,
+            },
+            Task {
+                start_time: 642,
+                end_time: 677,
+                cookies: 20,
+            },
+            Task {
+                start_time: 672,
+                end_time: 696,
+                cookies: 19,
+            },
+            Task {
+                start_time: 666,
+                end_time: 698,
+                cookies: 20,
+            },
+            Task {
+                start_time: 665,
+                end_time: 729,
+                cookies: 24,
+            },
+            Task {
+                start_time: 708,
+                end_time: 743,
+                cookies: 15,
+            },
+            Task {
+                start_time: 651,
+                end_time: 752,
+                cookies: 6,
+            },
+            Task {
+                start_time: 745,
+                end_time: 762,
+                cookies: 21,
+            },
+            Task {
+                start_time: 676,
+                end_time: 773,
+                cookies: 24,
+            },
+            Task {
+                start_time: 723,
+                end_time: 777,
+                cookies: 9,
+            },
+            Task {
+                start_time: 754,
+                end_time: 779,
+                cookies: 23,
+            },
+            Task {
+                start_time: 712,
+                end_time: 782,
+                cookies: 17,
+            },
+            Task {
+                start_time: 755,
+                end_time: 785,
+                cookies: 23,
+            },
+            Task {
+                start_time: 791,
+                end_time: 800,
+                cookies: 5,
+            },
+            Task {
+                start_time: 703,
+                end_time: 802,
+                cookies: 5,
+            },
+            Task {
+                start_time: 798,
+                end_time: 820,
+                cookies: 21,
+            },
+            Task {
+                start_time: 822,
+                end_time: 834,
+                cookies: 7,
+            },
+            Task {
+                start_time: 802,
+                end_time: 836,
+                cookies: 23,
+            },
+            Task {
+                start_time: 792,
+                end_time: 842,
+                cookies: 11,
+            },
+            Task {
+                start_time: 830,
+                end_time: 844,
+                cookies: 24,
+            },
+            Task {
+                start_time: 794,
+                end_time: 852,
+                cookies: 6,
+            },
+            Task {
+                start_time: 797,
+                end_time: 857,
+                cookies: 22,
+            },
+            Task {
+                start_time: 762,
+                end_time: 863,
+                cookies: 19,
+            },
+            Task {
+                start_time: 833,
+                end_time: 869,
+                cookies: 16,
+            },
+            Task {
+                start_time: 887,
+                end_time: 890,
+                cookies: 21,
+            },
+            Task {
+                start_time: 849,
+                end_time: 898,
+                cookies: 1,
+            },
+            Task {
+                start_time: 824,
+                end_time: 899,
+                cookies: 8,
+            },
+            Task {
+                start_time: 874,
+                end_time: 932,
+                cookies: 9,
+            },
+            Task {
+                start_time: 885,
+                end_time: 933,
+                cookies: 16,
+            },
+            Task {
+                start_time: 909,
+                end_time: 959,
+                cookies: 1,
+            },
+            Task {
+                start_time: 933,
+                end_time: 970,
+                cookies: 14,
+            },
+            Task {
+                start_time: 936,
+                end_time: 980,
+                cookies: 24,
+            },
+            Task {
+                start_time: 975,
+                end_time: 984,
+                cookies: 9,
+            },
+            Task {
+                start_time: 956,
+                end_time: 993,
+                cookies: 1,
+            },
+            Task {
+                start_time: 949,
+                end_time: 994,
+                cookies: 19,
+            },
+            Task {
+                start_time: 921,
+                end_time: 1000,
+                cookies: 1,
+            },
+            Task {
+                start_time: 984,
+                end_time: 1030,
+                cookies: 21,
+            },
+            Task {
+                start_time: 955,
+                end_time: 1042,
+                cookies: 13,
+            },
+            Task {
+                start_time: 994,
+                end_time: 1043,
+                cookies: 1,
+            },
+        ];
+
+        let mut testcase = Testcase {
+            tasks,
+            expected: 395,
+        };
+
+        scale_tests(&mut testcase);
+
+        assert_eq!(
+            time_manager(&mut testcase.tasks),
+            testcase.expected,
+            "Failed for {}",
+            testcase
+        );
+    }
+}


### PR DESCRIPTION
- Tests for all the exercises in module 01
- Renamed the function `largest_group` to `first_group` as the exercise has changed and this name is more accurate
- Fix in ex02 regarding the color range (number 128 was overlapping)
- Changed visibility of all functions to `pub` so we can the functions in the tester even though its a different module
- Tests are mostly randomized, the biggest exception is the last exercise where I basically just hard-coded some inputs, but I'm scaling them (basically just multiplying all values with a random number, and shuffling the order of the input, because if I do it completely random I'd need to include the solution to the function in the test, which we want to avoid since the repo is public)