### PR TITLE
feat(short/rust/tests/00)

### DIFF
--- a/rust/subjects/00/README.md
+++ b/rust/subjects/00/README.md
@@ -293,16 +293,21 @@ turn-in directory:
     ex05/
 
 files to turn in:
-    src/main.rs  Cargo.toml
+    src/lib.rs  Cargo.toml
 
 allowed symbols:
-    std::{assert, assert_eq, assert_ne}  std::panic  std::{print, println}
+    std::{assert, assert_eq, assert_ne}  std::panic  std::{write, writeln}
 ```
 
-Write a **program** which prints every Friday that falls on the 13th of the month, since the first
-day of year 1 (it was a monday) until today.
+Write a **function** which writes every Friday that falls on the 13th of the month, since the
+first day of year 1 (it was a monday) until (and including) the year passed as an argument.
+The output must be written into the writer W.
 
-To complete this task, you must write the following function:
+```rust
+pub fn friday_the_13th<W: std::io::Write>(writer: &mut W, year: u32);
+```
+
+To complete this task, you must also write the following functions:
 
 ```rust
 pub fn is_leap_year(year: u32) -> bool;
@@ -312,7 +317,15 @@ pub fn num_days_in_month(year: u32, month: u32) -> u32;
 * `is_leap_year` must determine whether a given year is a leap year or not.
 * `num_days_in_month` must compute how many days a given month of a given year has.
 
-Example:
+Example on how to call your `friday_the_13th` function in a `main.rs` file:
+
+```rust
+use ex05::friday_the_13th;
+
+fn main() {
+    friday_the_13th(&mut std::io::stdout(), 2025);
+}
+```
 
 ```
 >_ cargo run
@@ -327,6 +340,8 @@ Friday, May 13, 5
 Friday, January 13, 6
 Friday, October 13, 6
 ...
+Friday, December 13, 2024
+Friday, June 13, 2025
 ```
 
 You must add tests to your Cargo project to verify that `is_leap_year` and `num_days_in_month` both
@@ -339,7 +354,7 @@ work as expected. Specifically, you must show that:
 * February has 29 days on leap years, but 28 on common years.
 * Other months have the correct number of days on both leap and common years.
 * Passing an invalid month to `num_days_in_month` must make the function panic.
-* Passing an year `0` to `is_leap_year` must make the function panic.
+* Passing an year `0` to either of these three functions must make the function panic.
 
 It must be possible to run those tests using `cargo test`.
 

--- a/rust/subjects/00/README.md
+++ b/rust/subjects/00/README.md
@@ -84,7 +84,7 @@ Create a `min` **function** that takes two integers, and returns the smaller one
 The function must be prototyped like this:
 
 ```rust
-fn min(a: i32, b: i32) -> i32;
+pub fn min(a: i32, b: i32) -> i32;
 ```
 
 Oh, I almost forgot. The `return` keyword is forbidden in this exercise! Good luck with that ~
@@ -108,9 +108,9 @@ cannot use the same loop kind twice.
 The functions must be prototyped as follows:
 
 ```rust
-fn yes() -> !;
-fn collatz(start: u32);
-fn print_bytes(s: &str);
+pub fn yes() -> !;
+pub fn collatz(start: u32);
+pub fn print_bytes(s: &str);
 ```
 
 The `yes` function must print the message `y`, followed by a line feed. It must do it
@@ -305,8 +305,8 @@ day of year 1 (it was a monday) until today.
 To complete this task, you must write the following function:
 
 ```rust
-fn is_leap_year(year: u32) -> bool;
-fn num_days_in_month(year: u32, month: u32) -> u32;
+pub fn is_leap_year(year: u32) -> bool;
+pub fn num_days_in_month(year: u32, month: u32) -> u32;
 ```
 
 * `is_leap_year` must determine whether a given year is a leap year or not.

--- a/rust/subjects/00/README.md
+++ b/rust/subjects/00/README.md
@@ -293,39 +293,29 @@ turn-in directory:
     ex05/
 
 files to turn in:
-    src/lib.rs  Cargo.toml
+    src/main.rs src/lib.rs  Cargo.toml
 
 allowed symbols:
-    std::{assert, assert_eq, assert_ne}  std::panic  std::{write, writeln}
+    std::{assert, assert_eq, assert_ne}  std::panic  std::{write, writeln}  std::io::stdout
 ```
 
-Write a **function** which writes every Friday that falls on the 13th of the month, since the
-first day of year 1 (it was a monday) until (and including) the year passed as an argument.
-The output must be written into the writer W.
-
-```rust
-pub fn friday_the_13th<W: std::io::Write>(writer: &mut W, year: u32);
-```
+Write a **program** which prints every Friday that falls on the 13th of the month, since the
+first day of year 1 (it was a monday) until (and including) the year 2025.
 
 To complete this task, you must also write the following functions:
 
 ```rust
+pub fn friday_the_13th<W: std::io::Write>(writer: &mut W, year: u32);
 pub fn is_leap_year(year: u32) -> bool;
 pub fn num_days_in_month(year: u32, month: u32) -> u32;
 ```
 
+* `friday_the_13th` writes every Friday that falls on the 13th of the month
+since year 1 until the year given as an argument into the writer W
 * `is_leap_year` must determine whether a given year is a leap year or not.
 * `num_days_in_month` must compute how many days a given month of a given year has.
 
-Example on how to call your `friday_the_13th` function in a `main.rs` file:
-
-```rust
-use ex05::friday_the_13th;
-
-fn main() {
-    friday_the_13th(&mut std::io::stdout(), 2025);
-}
-```
+These three functions must be part of the `src/lib.rs` file.rs.
 
 ```
 >_ cargo run

--- a/rust/tester/Cargo.lock
+++ b/rust/tester/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +63,22 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -198,6 +220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +262,41 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -326,6 +392,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/rust/tester/Cargo.lock
+++ b/rust/tester/Cargo.lock
@@ -3,10 +3,31 @@
 version = 4
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -15,16 +36,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -72,6 +157,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +196,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,10 +218,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -169,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+
+[[package]]
 name = "rustix"
 version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +319,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -229,6 +374,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f08357795f0d604ea7d7130f22c74b03838c959bdb14adde3142aab4d18a293"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,10 +428,12 @@ name = "tester"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "fs_extra",
  "rand",
  "serde",
  "serde_json",
+ "similar-asserts",
  "tempfile",
  "toml",
 ]
@@ -306,10 +479,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/rust/tester/Cargo.toml
+++ b/rust/tester/Cargo.toml
@@ -10,3 +10,4 @@ rand = "0.8.5"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 tempfile = "3.14.0"
+toml = "0.8.19"

--- a/rust/tester/Cargo.toml
+++ b/rust/tester/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.94"
+chrono = "0.4.39"
 fs_extra = "1.3.0"
 rand = "0.8.5"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
+similar-asserts = "1.6.1"
 tempfile = "3.14.0"
 toml = "0.8.19"

--- a/rust/tester/src/module00/exercise00/mod.rs
+++ b/rust/tester/src/module00/exercise00/mod.rs
@@ -1,6 +1,9 @@
-use std::path;
+use std::{
+    path,
+    process::{self},
+};
 
-use crate::{repository_path, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise00;
@@ -8,5 +11,66 @@ pub struct Exercise00;
 impl Testable for Exercise00 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex00")
+    }
+
+    fn run_test(&self) -> TestResult {
+        let path = match self.compile() {
+            Ok(Some(path)) => path,
+            _ => {
+                eprintln!("Failed to compile");
+                return TestResult::CompilationError;
+            }
+        };
+
+        let output = match process::Command::new(&path).output() {
+            Ok(output) => output,
+            Err(_) => {
+                eprintln!("Failed to execute ./hello");
+                return TestResult::CompilationError;
+            }
+        };
+
+        if !output.status.success() {
+            eprintln!("Exited with non-0 exit code");
+            return TestResult::Failed;
+        }
+
+        if !output.stderr.is_empty() {
+            eprintln!(
+                "Unexpected output on stderr:\nExpected: \"\"\nGot: \"{}\"",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return TestResult::Failed;
+        }
+
+        if output.stdout != "Hello, World!\n".as_bytes() {
+            eprintln!(
+                "Incorrect output on stdout: \nExpected: \"Hello, World!\n\"\nGot: \"{}\"",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
+    }
+
+    fn compile(&self) -> Result<Option<path::PathBuf>, TestResult> {
+        self.ensure_path();
+
+        let source_file = self.path().join("hello.rs");
+
+        let output = process::Command::new("rustc")
+            .current_dir(self.path())
+            .arg(&source_file)
+            .output()
+            .expect("Failed to compile hello.rs");
+
+        if !output.status.success() {
+            return Err(TestResult::CompilationError);
+        }
+
+        let path = self.path().join("hello");
+
+        Ok(Some(path))
     }
 }

--- a/rust/tester/src/module00/exercise01/mod.rs
+++ b/rust/tester/src/module00/exercise01/mod.rs
@@ -1,6 +1,9 @@
+use fs_extra::file::CopyOptions;
+use std::fs::File;
+use std::io::Write;
 use std::path;
 
-use crate::{repository_path, testable::Testable};
+use crate::{cargo::Cargo, repository_path, result::TestResult, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise01;
@@ -8,5 +11,47 @@ pub struct Exercise01;
 impl Testable for Exercise01 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex01")
+    }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
+
+    fn run_test(&self) -> TestResult {
+        if let Err(test_output) = self.run_cargo_tests() {
+            eprintln!("{test_output}");
+
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
+    }
+
+    fn prepare_cargo_tests(&self) -> Cargo {
+        let cargo = Cargo::new("shortinette-test-module00-ex01", true);
+
+        cargo
+            .add_dependency("rand", "0.8")
+            .expect("Failed to add rand as dependency to test project");
+
+        let mut lib_file = File::create(cargo.path().join("src/lib.rs"))
+            .expect("Failed to open src/lib.rs of test module");
+        lib_file
+            .write_all(self.cargo_test_mod().as_bytes())
+            .expect("Failed to write test module into src/lib.rs of test module");
+
+        let files = ["min.rs"];
+
+        let options = CopyOptions::new().overwrite(true);
+        for file in files {
+            fs_extra::file::copy(
+                &self.ensure_path().join(file),
+                cargo.path().join("src").join(file),
+                &options,
+            )
+            .expect("Unable to copy file into cargo project");
+        }
+
+        cargo
     }
 }

--- a/rust/tester/src/module00/exercise01/shortinette_tests.rs
+++ b/rust/tester/src/module00/exercise01/shortinette_tests.rs
@@ -1,0 +1,50 @@
+mod min;
+
+#[cfg(test)]
+mod shortinette_tests_0001 {
+    use crate::min::min;
+    use rand::{random, Rng};
+
+    #[test]
+    fn test_equal() {
+        let number = random::<i32>();
+
+        assert_eq!(
+            min(number, number),
+            number,
+            "Failed with ({}, {})",
+            number,
+            number
+        );
+    }
+
+    #[test]
+    fn test_a_lower() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(i32::MIN..i32::MAX);
+        let b = rng.gen_range(a + 1..=i32::MAX);
+
+        assert_eq!(min(a, b), a, "Failed with ({}, {})", a, b);
+    }
+
+    #[test]
+    fn test_b_lower() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(i32::MIN + 1..=i32::MAX);
+        let b = rng.gen_range(i32::MIN..a);
+
+        assert_eq!(min(a, b), b, "Failed with ({}, {})", a, b);
+    }
+
+    #[test]
+    fn test_negative_and_zero() {
+        let mut rng = rand::thread_rng();
+
+        let a = rng.gen_range(i32::MIN..0);
+        let b = 0;
+
+        assert_eq!(min(a, b), a, "Failed with ({}, {})", a, b);
+    }
+}

--- a/rust/tester/src/module00/exercise02/mod.rs
+++ b/rust/tester/src/module00/exercise02/mod.rs
@@ -1,4 +1,11 @@
+use crate::cargo::Cargo;
+use crate::TestResult;
+use fs_extra::file::CopyOptions;
+use rand::prelude::SliceRandom;
+use std::fs::File;
+use std::io::Write;
 use std::path;
+use std::process::Command;
 
 use crate::{repository_path, testable::Testable};
 
@@ -8,5 +15,93 @@ pub struct Exercise02;
 impl Testable for Exercise02 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex02")
+    }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
+
+    fn run_test(&self) -> TestResult {
+        if let Err(test_output) = self.run_cargo_tests() {
+            eprintln!("{test_output}");
+
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
+    }
+
+    fn run_cargo_tests(&self) -> Result<(), String> {
+        let cargo = self.prepare_cargo_tests();
+
+        let mut cargo_test_list = cargo.test_list(&["shortinette_tests"]);
+        assert!(!cargo_test_list.is_empty(), "No shortinette tests found");
+
+        let command = Command::new("cargo")
+            .current_dir(cargo.path())
+            .arg("build")
+            .arg("--release")
+            .output()
+            .expect("Unable to run cargo build");
+
+        assert!(
+            command.status.success(),
+            "Unable to compile program\n{}",
+            String::from_utf8_lossy(&command.stderr)
+        );
+
+        let mut rng = rand::thread_rng();
+        cargo_test_list.shuffle(&mut rng);
+
+        let mut failed_output = Vec::new();
+        for test in cargo_test_list {
+            let Err(test_output) = cargo.run_test([test.as_str()]) else {
+                continue;
+            };
+
+            failed_output.push(test_output);
+        }
+
+        if failed_output.is_empty() {
+            Ok(())
+        } else {
+            Err(failed_output.join("\n"))
+        }
+    }
+
+    fn prepare_cargo_tests(&self) -> Cargo {
+        let cargo = Cargo::new("shortinette-test-module00-ex02", false);
+
+        cargo
+            .add_dependency("rand", "0.8")
+            .expect("Failed to add rand as dependency to test project");
+
+        cargo
+            .add_dependency("base64", "0.22")
+            .expect("Failed to add base64 as dependency to test project");
+
+        cargo
+            .add_dependency("wait-timeout", "0.2")
+            .expect("Failed to add wait-timeout as dependency to test project");
+
+        let mut main_file = File::create(cargo.path().join("src/main.rs"))
+            .expect("Failed to open src/main.rs of test module");
+        main_file
+            .write_all(self.cargo_test_mod().as_bytes())
+            .expect("Failed to write test module into src/main.rs of test module");
+
+        let files = ["yes.rs", "collatz.rs", "print_bytes.rs"];
+
+        let options = CopyOptions::new().overwrite(true);
+        for file in files {
+            fs_extra::file::copy(
+                &self.ensure_path().join(file),
+                cargo.path().join("src").join(file),
+                &options,
+            )
+            .expect("Unable to copy file into cargo project");
+        }
+
+        cargo
     }
 }

--- a/rust/tester/src/module00/exercise02/shortinette_tests.rs
+++ b/rust/tester/src/module00/exercise02/shortinette_tests.rs
@@ -1,0 +1,248 @@
+mod collatz;
+mod print_bytes;
+mod yes;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use std::env;
+
+#[cfg(test)]
+mod shortinette_tests_0002 {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use rand::{distributions::Alphanumeric, Rng};
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+    use wait_timeout::ChildExt;
+
+    fn format_non_printable(s: &str) -> String {
+        s.chars()
+            .map(|c| match c {
+                '\0' => format!("\\0"),
+                '\n' => format!("\\n"),
+                _ => c.to_string(),
+            })
+            .collect()
+    }
+
+    fn print_bytes_helper(input: &str) {
+        let encoded = STANDARD.encode(input);
+
+        let run_output = Command::new("target/release/shortinette-test-module00-ex02")
+            .arg("print_bytes")
+            .arg(encoded)
+            .output()
+            .expect("Failed to execute program with print_bytes() function");
+
+        if !run_output.stderr.is_empty() {
+            panic!(
+                "Unexpected content on stderr: {}",
+                String::from_utf8_lossy(&run_output.stderr)
+            );
+        }
+
+        let output = String::from_utf8_lossy(&run_output.stdout);
+        let lines: Vec<_> = output
+            .lines()
+            .map(|line| line.parse::<u8>().expect("Unable to parse line into u8"))
+            .collect();
+
+        assert_eq!(
+            input.as_bytes(),
+            lines,
+            "Output doesn't match with input '{}'",
+            format_non_printable(input)
+        );
+    }
+
+    #[test]
+    fn test_print_bytes_subject() {
+        print_bytes_helper("Déjà Vu\n");
+    }
+
+    #[test]
+    fn test_print_bytes_empty() {
+        print_bytes_helper("");
+    }
+
+    #[test]
+    fn test_print_bytes_0_byte() {
+        print_bytes_helper("\0");
+    }
+
+    fn random_string(size: usize) -> String {
+        let mut rng = rand::thread_rng();
+        (0..size)
+            .map(|_| rng.sample(Alphanumeric))
+            .map(char::from)
+            .collect()
+    }
+
+    #[test]
+    fn test_print_bytes_random() {
+        let randstring = random_string(32);
+
+        print_bytes_helper(&randstring);
+    }
+
+    #[test]
+    fn test_print_bytes_random_with_0_byte() {
+        let mut randstring = random_string(32);
+        randstring.push('\0');
+
+        print_bytes_helper(&randstring);
+    }
+
+    #[test]
+    fn test_print_bytes_random_unicode() {
+        let mut randstring = random_string(32);
+        randstring.push('🦀');
+
+        print_bytes_helper(&randstring);
+    }
+
+    fn execute_with_timeout(arguments: &[&str], timeout_expected: bool) -> String {
+        let mut child = Command::new("target/release/shortinette-test-module00-ex02")
+            .args(arguments)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Unable to execute program");
+
+        let result = child.wait_timeout(Duration::from_secs(3)).unwrap();
+
+        if timeout_expected && result.is_some() {
+            panic!("Program exited too early");
+        }
+
+        if result.is_none() {
+            child.kill().expect("Unable to kill process");
+            child.wait().expect("Unable to wait for process");
+        }
+
+        if !timeout_expected && result.is_none() {
+            panic!("Program didn't finish in time");
+        }
+
+        let mut stderr = String::new();
+        child
+            .stderr
+            .take()
+            .expect("Unable to get stderr from program")
+            .read_to_string(&mut stderr);
+
+        if !stderr.is_empty() {
+            panic!("Unexpected content on stderr: {}", stderr);
+        }
+
+        let mut output = String::new();
+        child
+            .stdout
+            .take()
+            .expect("Unable to get stdout from program")
+            .read_to_string(&mut output);
+
+        output
+    }
+
+    fn validate_collatz_output(input: u32, output: String) {
+        let mut expected = input;
+
+        for (index, line) in output.lines().enumerate() {
+            let received = line
+                .parse::<u32>()
+                .expect("Unable to parse output into u32");
+
+            assert_eq!(
+                received,
+                expected,
+                "Incorrect output in Line {}, Expected {}, Got {}",
+                index + 1,
+                expected,
+                received
+            );
+
+            if expected % 2 == 0 {
+                expected /= 2;
+            } else if expected != 1 {
+                expected = expected * 3 + 1;
+            }
+        }
+
+        assert_eq!(expected, 1, "Empty or incomplete output");
+    }
+
+    #[test]
+    fn test_yes() {
+        let output = execute_with_timeout(&["yes"], true);
+
+        if output.is_empty() {
+            panic!("Empty output from yes() function");
+        }
+
+        for (index, line) in output.lines().enumerate() {
+            if line != "y" {
+                panic!("Invalid content on line {}: {}", index + 1, line);
+            }
+        }
+
+        if output.lines().count() < 10000 {
+            panic!("Expected more lines of output");
+        }
+    }
+
+    #[test]
+    fn test_collatz_0_endless_loop() {
+        let output = execute_with_timeout(&["collatz", "0"], false);
+
+        assert!(output.is_empty(), "Invalid output with collatz(0)");
+    }
+
+    #[test]
+    fn test_collatz_1() {
+        let output = execute_with_timeout(&["collatz", "1"], false);
+
+        assert_eq!(output, "1\n", "Invalid output with collatz(1)");
+    }
+
+    #[test]
+    fn test_collatz_random() {
+        let mut rng = rand::thread_rng();
+
+        let input = rng.gen_range(1000..10000);
+        let arg = format!("{}", input);
+        let output = execute_with_timeout(&["collatz", &arg], false);
+
+        validate_collatz_output(input, output);
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        panic!("Not enough arguments");
+    }
+
+    match args[1].as_str() {
+        "yes" => yes::yes(),
+        "print_bytes" => {
+            if args.len() < 3 {
+                panic!("Not enough arguments");
+            }
+
+            let decoded = STANDARD.decode(&args[2]).expect("Unable to decode base64");
+            print_bytes::print_bytes(&String::from_utf8_lossy(&decoded));
+        }
+        "collatz" => {
+            if args.len() < 3 {
+                panic!("Not enough arguments");
+            }
+            collatz::collatz(
+                args[2]
+                    .parse::<u32>()
+                    .expect("Unable to parse collatz value into u32"),
+            );
+        }
+        _ => panic!("Invalid command"),
+    }
+}

--- a/rust/tester/src/module00/exercise03/mod.rs
+++ b/rust/tester/src/module00/exercise03/mod.rs
@@ -1,12 +1,119 @@
 use std::path;
 
-use crate::{repository_path, testable::Testable};
+use crate::{repository_path, testable::Testable, TestResult};
+use std::fmt;
+use std::fmt::Write;
+use std::process::Command;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise03;
 
+/*
+* Intentionally using if conditions so nobody can just copy the function
+* (once we actually have the keyword check)
+*/
+fn expected_output(number: usize) -> Result<String, fmt::Error> {
+    let mut output = String::new();
+
+    if number % 3 == 0 {
+        output.push_str("fizz");
+    }
+
+    if number % 5 == 0 {
+        output.push_str("buzz");
+    }
+
+    if output.is_empty() {
+        match number % 11 {
+            3 => output.push_str("FIZZ"),
+            5 => output.push_str("BUZZ"),
+            _ => write!(&mut output, "{}", number)?,
+        }
+    }
+
+    Ok(output)
+}
+
 impl Testable for Exercise03 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex03")
+    }
+
+    fn run_test(&self) -> TestResult {
+        let path = match self.compile() {
+            Ok(Some(path)) => path,
+            _ => {
+                eprintln!("Failed to compile");
+                return TestResult::CompilationError;
+            }
+        };
+
+        let output = match Command::new(&path).output() {
+            Ok(output) => output,
+            Err(_) => {
+                eprintln!("Failed to execute ./fizzbuzz");
+                return TestResult::CompilationError;
+            }
+        };
+
+        if !output.status.success() {
+            eprintln!("Exited with non-0 exit code");
+            return TestResult::Failed;
+        }
+
+        if !output.stderr.is_empty() {
+            eprintln!(
+                "Unexpected output on stderr:\nExpected: \"\"\nGot: \"{}\"",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return TestResult::Failed;
+        }
+
+        let output_string = String::from_utf8_lossy(&output.stdout);
+        for (i, line) in output_string.lines().enumerate() {
+            if i >= 100 {
+                eprintln!("Too many lines in output!");
+                return TestResult::Failed;
+            }
+
+            let expected = match expected_output(i + 1) {
+                Ok(value) => value,
+                Err(e) => {
+                    eprintln!("Internal error: {}", e);
+                    return TestResult::Failed;
+                }
+            };
+            if expected != line {
+                eprintln!(
+                    "Output differs in line {}\nExpected: {}\nGot: {}",
+                    i + 1,
+                    expected,
+                    line
+                );
+                return TestResult::Failed;
+            }
+        }
+
+        TestResult::Passed
+    }
+
+    fn compile(&self) -> Result<Option<path::PathBuf>, TestResult> {
+        self.ensure_path();
+
+        let source_file = self.path().join("fizzbuzz.rs");
+
+        let output = Command::new("rustc")
+            .current_dir(self.path())
+            .arg(&source_file)
+            .output()
+            .expect("Failed to compile fizzbuzz.rs");
+
+        if !output.status.success() {
+            return Err(TestResult::CompilationError);
+        }
+
+        let path = self.path().join("fizzbuzz");
+
+        Ok(Some(path))
     }
 }

--- a/rust/tester/src/module00/exercise04/mod.rs
+++ b/rust/tester/src/module00/exercise04/mod.rs
@@ -1,12 +1,289 @@
-use std::path;
+use rand::seq::SliceRandom;
+use serde::Deserialize;
+use std::{
+    fs,
+    path::{self, PathBuf},
+    process::Command,
+};
 
-use crate::{repository_path, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise04;
 
+#[derive(Deserialize)]
+struct PackageConfig {
+    name: String,
+    edition: Option<String>,
+    description: Option<String>,
+    authors: Option<Vec<String>>,
+    publish: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct CargoToml {
+    package: PackageConfig,
+}
+
+fn read_cargo_toml(path: &PathBuf) -> Option<CargoToml> {
+    let content = match fs::read_to_string(path) {
+        Ok(str) => str,
+        Err(err) => {
+            eprintln!("Unable to read Cargo.toml: {}", err);
+            return None;
+        }
+    };
+
+    let cargotoml: CargoToml = match toml::from_str(&content) {
+        Ok(toml) => toml,
+        Err(e) => {
+            eprintln!("Unable to deserialize Cargo.toml: {}", e);
+            return None;
+        }
+    };
+
+    Some(cargotoml)
+}
+
+fn check_cargo_toml(path: &PathBuf) -> bool {
+    let cargotoml = match read_cargo_toml(path) {
+        Some(toml) => toml,
+        None => return false,
+    };
+
+    if cargotoml.package.name != "module00-ex04" {
+        eprintln!("Incorrect module name: '{}'", cargotoml.package.name);
+        return false;
+    }
+
+    if cargotoml
+        .package
+        .edition
+        .is_none_or(|value| value != "2021")
+    {
+        eprintln!("Edition is not set to 2021");
+        return false;
+    }
+
+    if cargotoml
+        .package
+        .authors
+        .is_none_or(|authors| authors.len() != 1 || authors[0].is_empty())
+    {
+        eprintln!("Author check failed");
+        return false;
+    }
+
+    if cargotoml
+        .package
+        .description
+        .as_ref()
+        .is_none_or(|description| {
+            description
+                != "my answer to the fifth exercise of the first module of 42's Rust Piscine"
+        })
+    {
+        eprintln!(
+            "Incorrect description: '{:?}'",
+            cargotoml.package.description
+        );
+        return false;
+    }
+
+    if cargotoml.package.publish.is_none_or(|publish| publish) {
+        eprintln!("Publish not set to false");
+        return false;
+    }
+
+    true
+}
+
+struct TestOutput<'a> {
+    exit_code: i32,
+    profile: Option<&'a str>,
+    expected_output: &'a str,
+}
+
+struct TestConfig<'a> {
+    target: Option<&'a str>,
+    executable_name: &'a str,
+    test_output: &'a TestOutput<'a>,
+}
+
+impl<'a> TestConfig<'a> {
+    fn new(target: Option<&'a str>, test_output: &'a TestOutput) -> Self {
+        let executable_name = target.unwrap_or("module00-ex04");
+
+        Self {
+            target,
+            executable_name,
+            test_output,
+        }
+    }
+}
+
+fn nm_check(path: &PathBuf, testconfig: &TestConfig) -> bool {
+    let profile_folder = testconfig.test_output.profile.unwrap_or("debug");
+    let path = path
+        .join("target")
+        .join(profile_folder)
+        .join(testconfig.executable_name);
+    let release = testconfig
+        .test_output
+        .profile
+        .is_some_and(|profile| profile == "release");
+
+    let command = Command::new("nm").arg(path).output();
+
+    if let Ok(output) = command {
+        if !output.status.success() {
+            eprintln!("nm didn't execute successfully");
+            return false;
+        } else if !output.stderr.is_empty()
+            && !String::from_utf8_lossy(&output.stderr).contains("no symbols")
+        {
+            eprintln!(
+                "Unexpected content on stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return false;
+        } else if release && !output.stdout.is_empty() {
+            eprintln!("Debugging symbols haven't been stripped in Release mode!");
+            return false;
+        } else if !release && output.stdout.is_empty() {
+            eprintln!("Debugging symbols should only be stripped in Release mode!");
+            return false;
+        }
+    }
+    true
+}
+
+fn run_executable(path: &PathBuf, testconfig: &TestConfig) -> bool {
+    let mut binding = Command::new("cargo");
+    let mut command = binding.current_dir(path).arg("run");
+
+    if let Some(profile) = testconfig.test_output.profile {
+        command = command.arg("--profile").arg(profile);
+    }
+
+    if let Some(target) = testconfig.target {
+        command = command.arg("--bin").arg(target);
+    }
+
+    let output = command.output();
+    if let Ok(output) = output {
+        if let Some(exitcode) = output.status.code() {
+            if exitcode != testconfig.test_output.exit_code {
+                eprintln!(
+                    "Incorrect exit code, expected {}, got {}",
+                    testconfig.test_output.exit_code, exitcode
+                );
+                return false;
+            }
+        }
+
+        let received_output = String::from_utf8_lossy(&output.stdout);
+        if received_output != testconfig.test_output.expected_output {
+            eprintln!(
+                "Output differs\nExpected: '{}'\nGot: '{}'",
+                testconfig.test_output.expected_output, received_output
+            );
+            return false;
+        }
+
+        if !nm_check(&path, testconfig) {
+            return false;
+        }
+    } else {
+        eprintln!("Unable to execute cargo run");
+        return false;
+    }
+    true
+}
+
 impl Testable for Exercise04 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex04")
+    }
+
+    fn run_test(&self) -> TestResult {
+        let mut rng = rand::thread_rng();
+
+        if !self.check_clippy() {
+            eprintln!("`cargo clippy -- -D warnings` failed");
+
+            return TestResult::CompilationError;
+        }
+
+        if self.compile().is_err() {
+            eprintln!("Failed to compile");
+
+            return TestResult::CompilationError;
+        }
+
+        if !check_cargo_toml(&self.ensure_path().join("Cargo.toml")) {
+            return TestResult::Failed;
+        }
+
+        let mut tests = [
+            TestConfig::new(
+                None,
+                &TestOutput {
+                    exit_code: 0,
+                    profile: None,
+                    expected_output: "Hello, Cargo!\n",
+                },
+            ),
+            TestConfig::new(
+                None,
+                &TestOutput {
+                    exit_code: 0,
+                    profile: Some("release"),
+                    expected_output: "Hello, Cargo!\n",
+                },
+            ),
+            TestConfig::new(
+                Some("other"),
+                &TestOutput {
+                    exit_code: 0,
+                    profile: None,
+                    expected_output: "Hey! I'm the other bin target!\n",
+                },
+            ),
+            TestConfig::new(
+                Some("other"),
+                &TestOutput {
+                    exit_code: 0,
+                    profile: Some("release"),
+                    expected_output: "Hey! I'm the other bin target!\nI'm in release mode!\n",
+                },
+            ),
+            TestConfig::new(
+                Some("test-overflows"),
+                &TestOutput {
+                    exit_code: 101,
+                    profile: None,
+                    expected_output: "",
+                },
+            ),
+            TestConfig::new(
+                Some("test-overflows"),
+                &TestOutput {
+                    exit_code: 0,
+                    profile: Some("no-overflows"),
+                    expected_output: "255u8 + 1u8 == 0\n",
+                },
+            ),
+        ];
+
+        tests.shuffle(&mut rng);
+
+        for test in &tests {
+            if !run_executable(&self.ensure_path(), test) {
+                return TestResult::Failed;
+            }
+        }
+
+        TestResult::Passed
     }
 }

--- a/rust/tester/src/module00/exercise05/mod.rs
+++ b/rust/tester/src/module00/exercise05/mod.rs
@@ -1,9 +1,28 @@
+use crate::TestResult;
+use chrono::{Datelike, NaiveDate, Weekday};
+use similar_asserts::SimpleDiff;
 use std::path;
+use std::process::Command;
 
 use crate::{repository_path, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise05;
+
+fn expected_output(year: u32) -> String {
+    (1..=year)
+        .flat_map(move |year| {
+            (1..=12).filter_map(move |month| {
+                let date = NaiveDate::from_ymd_opt(year.try_into().unwrap(), month, 13).unwrap();
+                if date.weekday() != Weekday::Fri {
+                    None
+                } else {
+                    Some(format!("Friday, {} 13, {}\n", date.format("%B"), year))
+                }
+            })
+        })
+        .collect()
+}
 
 impl Testable for Exercise05 {
     fn path(&self) -> path::PathBuf {
@@ -12,5 +31,58 @@ impl Testable for Exercise05 {
 
     fn cargo_test_mod(&self) -> &'static str {
         include_str!("./shortinette_tests.rs")
+    }
+
+    fn run_test(&self) -> TestResult {
+        if !self.check_clippy() {
+            eprintln!("`cargo clippy -- -D warnings` failed");
+
+            return TestResult::CompilationError;
+        }
+
+        if self.compile().is_err() {
+            eprintln!("Failed to compile");
+
+            return TestResult::CompilationError;
+        }
+
+        if let Err(test_output) = self.run_cargo_tests() {
+            eprintln!("{test_output}");
+
+            return TestResult::Failed;
+        }
+
+        let command = Command::new("cargo")
+            .current_dir(self.path())
+            .arg("run")
+            .arg("--release")
+            .arg("--quiet")
+            .output()
+            .expect("Unable to execute cargo run");
+
+        if !command.status.success() {
+            eprintln!(
+                "Error when executing cargo run: {}",
+                String::from_utf8_lossy(&command.stderr)
+            );
+        }
+
+        if !command.stderr.is_empty() {
+            eprintln!(
+                "Unexpected output on stderr: {}",
+                String::from_utf8_lossy(&command.stderr)
+            );
+        }
+
+        let expected = expected_output(2025);
+        let actual = String::from_utf8_lossy(&command.stdout);
+
+        if expected != actual {
+            let diff = SimpleDiff::from_str(&actual, &expected, "got", "expected");
+            eprintln!("Incorrect output from cargo run\n{}", diff);
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
     }
 }

--- a/rust/tester/src/module00/exercise05/mod.rs
+++ b/rust/tester/src/module00/exercise05/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise05 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex05")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module00/exercise05/shortinette_tests.rs
+++ b/rust/tester/src/module00/exercise05/shortinette_tests.rs
@@ -1,0 +1,300 @@
+#[cfg(test)]
+mod shortinette_tests_0005 {
+    use chrono::{Datelike, NaiveDate, Weekday};
+    use ex05::{friday_the_13th, is_leap_year, num_days_in_month};
+    use rand::Rng;
+    use similar_asserts;
+
+    fn expected_output(year: u32) -> String {
+        (1..=year)
+            .flat_map(move |year| {
+                (1..=12).filter_map(move |month| {
+                    let date =
+                        NaiveDate::from_ymd_opt(year.try_into().unwrap(), month, 13).unwrap();
+                    if date.weekday() != Weekday::Fri {
+                        None
+                    } else {
+                        Some(format!("Friday, {} 13, {}\n", date.format("%B"), year))
+                    }
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_year() {
+        is_leap_year(0);
+    }
+
+    // This one is just to make sure it doesn't panic with year 1
+    #[test]
+    fn test_year_1() {
+        let result = is_leap_year(1);
+
+        assert_eq!(result, false, "Year 1 is not a leap year");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_month_0() {
+        let mut rng = rand::thread_rng();
+
+        num_days_in_month(rng.gen_range(1..2025), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_month_1() {
+        let mut rng = rand::thread_rng();
+
+        num_days_in_month(rng.gen_range(1..2025), 13);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_month_2() {
+        let mut rng = rand::thread_rng();
+
+        num_days_in_month(rng.gen_range(1..2025), rng.gen_range(14..100));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_num_days_in_month_year_0() {
+        let mut rng = rand::thread_rng();
+
+        num_days_in_month(0, rng.gen_range(1..=12));
+    }
+
+    #[test]
+    fn test_subject_1600() {
+        assert_eq!(
+            is_leap_year(1600),
+            true,
+            "Incorrect return value, expected true when calling is_leap_year(1600)"
+        );
+    }
+
+    #[test]
+    fn test_subject_1500() {
+        assert_eq!(
+            is_leap_year(1500),
+            false,
+            "Incorrect return value, expected false when calling is_leap_year(1500)"
+        );
+    }
+
+    #[test]
+    fn test_subject_2004() {
+        assert_eq!(
+            is_leap_year(2004),
+            true,
+            "Incorrect return value, expected true when calling is_leap_year(2004)"
+        );
+    }
+
+    #[test]
+    fn test_subject_2003() {
+        assert_eq!(
+            is_leap_year(2003),
+            false,
+            "Incorrect return value, expected false when calling is_leap_year(2003)"
+        );
+    }
+
+    #[test]
+    fn test_leap_year_100() {
+        let mut rng = rand::thread_rng();
+
+        let year: u32 = rng.gen_range(1..10) * 400 + 100;
+        assert_eq!(
+            is_leap_year(year),
+            false,
+            "Incorrect return value, expected false when calling is_leap_year({})",
+            year
+        );
+    }
+
+    #[test]
+    fn test_leap_year_200() {
+        let mut rng = rand::thread_rng();
+
+        let year: u32 = rng.gen_range(1..10) * 400 + 200;
+        assert_eq!(
+            is_leap_year(year),
+            false,
+            "Incorrect return value, expected false when calling is_leap_year({})",
+            year
+        );
+    }
+
+    #[test]
+    fn test_leap_year_300() {
+        let mut rng = rand::thread_rng();
+
+        let year: u32 = rng.gen_range(1..10) * 400 + 300;
+        assert_eq!(
+            is_leap_year(year),
+            false,
+            "Incorrect return value, expected false when calling is_leap_year({})",
+            year
+        );
+    }
+
+    #[test]
+    fn test_leap_year_mod_400() {
+        let mut rng = rand::thread_rng();
+
+        let year = rng.gen_range(1..10) * 400;
+        assert_eq!(
+            is_leap_year(year),
+            true,
+            "Incorrect return value, expected true when calling is_leap_year({})",
+            year
+        );
+    }
+
+    #[test]
+    fn test_leap_year_4() {
+        let mut rng = rand::thread_rng();
+        let mut year;
+
+        loop {
+            year = rng.gen_range(1..1000) * 4;
+            if year % 100 != 0 {
+                break;
+            }
+        }
+
+        assert_eq!(
+            is_leap_year(year),
+            true,
+            "Incorrect return value, expected true when calling is_leap_year({})",
+            year
+        );
+    }
+
+    #[test]
+    fn test_leap_year_false() {
+        let mut rng = rand::thread_rng();
+        let year = rng.gen_range(1..1000) * 4 + rng.gen_range(1..=3);
+
+        assert_eq!(
+            is_leap_year(year),
+            false,
+            "Incorrect return value, expected true when calling is_leap_year({})",
+            year
+        );
+    }
+
+    macro_rules! generate_test {
+        ($name:ident, $month:literal, $leap_year:literal, $expected:literal) => {
+            #[test]
+            fn $name() {
+                let mut rng = rand::thread_rng();
+                let mut year;
+
+                loop {
+                    year = rng.gen_range(1..1000) * 4;
+                    if !$leap_year {
+                        year += rng.gen_range(1..=3);
+                    }
+
+                    if year % 100 != 0 {
+                        break;
+                    }
+                }
+
+                assert_eq!(
+                    num_days_in_month(year, $month),
+                    $expected,
+                    "Incorrect return value, expected {} when calling num_days_in_month({}, {})",
+                    $expected,
+                    year,
+                    $month
+                );
+            }
+        };
+    }
+
+    generate_test!(test_january_leap_year, 1, true, 31);
+    generate_test!(test_january_common_year, 1, false, 31);
+    generate_test!(test_february_leap_year_0, 2, true, 29);
+
+    #[test]
+    fn test_february_leap_year_1() {
+        let mut rng = rand::thread_rng();
+        let year = rng.gen_range(1..10) * 400;
+
+        assert_eq!(
+            num_days_in_month(year, 2),
+            29,
+            "Incorrect return value, expected 29 when calling num_days_in_month({}, {})",
+            year,
+            2
+        );
+    }
+
+    generate_test!(test_february_common_year_0, 2, false, 28);
+
+    #[test]
+    fn test_february_common_year_1() {
+        let mut rng = rand::thread_rng();
+        let year = rng.gen_range(1..10) * 400 + rng.gen_range(1..=3) * 100;
+
+        assert_eq!(
+            num_days_in_month(year, 2),
+            28,
+            "Incorrect return value, expected 28 when calling num_days_in_month({}, {})",
+            year,
+            2
+        );
+    }
+
+    generate_test!(test_march_leap_year, 3, true, 31);
+    generate_test!(test_march_common_year, 3, false, 31);
+    generate_test!(test_april_leap_year, 4, true, 30);
+    generate_test!(test_april_common_year, 4, false, 30);
+    generate_test!(test_may_leap_year, 5, true, 31);
+    generate_test!(test_may_common_year, 5, false, 31);
+    generate_test!(test_june_leap_year, 6, true, 30);
+    generate_test!(test_june_common_year, 6, false, 30);
+    generate_test!(test_july_leap_year, 7, true, 31);
+    generate_test!(test_july_common_year, 7, false, 31);
+    generate_test!(test_august_leap_year, 8, true, 31);
+    generate_test!(test_august_common_year, 8, false, 31);
+    generate_test!(test_september_leap_year, 9, true, 30);
+    generate_test!(test_september_common_year, 9, false, 30);
+    generate_test!(test_october_leap_year, 10, true, 31);
+    generate_test!(test_october_common_year, 10, false, 31);
+    generate_test!(test_november_leap_year, 11, true, 30);
+    generate_test!(test_november_common_year, 11, false, 30);
+    generate_test!(test_december_leap_year, 12, true, 31);
+    generate_test!(test_december_common_year, 12, false, 31);
+
+    #[test]
+    fn test_output() {
+        let mut rng = rand::thread_rng();
+        let mut buffer: Vec<u8> = Vec::new();
+
+        let year: u32 = rng.gen_range(1500..4000);
+        friday_the_13th(&mut buffer, year);
+        let output = String::from_utf8_lossy(&buffer);
+        let expected = expected_output(year);
+        similar_asserts::assert_eq!(
+            output,
+            expected,
+            "Output differs with friday_the_13th() and year {}",
+            year
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_friday_the_13th_year_0() {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        friday_the_13th(&mut buffer, 0);
+    }
+}

--- a/rust/tester/src/module00/exercise06/mod.rs
+++ b/rust/tester/src/module00/exercise06/mod.rs
@@ -1,12 +1,151 @@
-use std::path;
+use std::collections::HashSet;
+use std::io::{self, BufRead, BufReader, Read};
+use std::path::{self, PathBuf};
+use std::process::{Command, Stdio};
 
-use crate::{repository_path, testable::Testable};
+use crate::{repository_path, result::TestResult, testable::Testable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exercise06;
 
+fn validate_first_line<R: io::Read>(reader: &mut BufReader<R>) -> Result<(), String> {
+    let mut output = String::new();
+
+    reader
+        .read_line(&mut output)
+        .map_err(|e| format!("Unable to read line: {}", e.to_string()))?;
+
+    if output != "Me and my infinite wisdom have found an appropriate secret you shall yearn for.\n"
+    {
+        return Err(format!("Incorrect content on first line: {}", output));
+    }
+
+    Ok(())
+}
+
+fn play_guessing_game<R: io::Read, W: io::Write>(
+    reader: &mut BufReader<R>,
+    writer: &mut W,
+) -> Result<i64, String> {
+    let mut output = String::new();
+    let mut min: i64 = i32::MIN.into();
+    let mut max: i64 = i32::MAX.into();
+
+    validate_first_line(reader)?;
+
+    loop {
+        let current = (min + max) / 2;
+
+        writer
+            .write_all(format!("{}\n", current).as_bytes())
+            .map_err(|err| format!("Unable to write into stdin: {}", err.to_string()))?;
+
+        writer.flush().unwrap();
+
+        reader
+            .read_line(&mut output)
+            .map_err(|err| format!("Unable to read line from stdout: {}", err.to_string()))?;
+
+        let correct_str = format!("That is right! The secret was indeed the number {}, which you have brilliantly discovered!\n", current);
+
+        if correct_str == output {
+            return Ok(current);
+        } else if min == max {
+            return Err(format!(
+                "Incorrect output\nExpected: {}Got: {}",
+                correct_str, output
+            ));
+        }
+
+        match output.as_str() {
+            "This student might not be as smart as I was told. This answer is obviously too weak.\n" => min = current + 1,
+            "Sometimes I wonder whether I should retire. I would have guessed higher.\n" => max = current - 1,
+            _ => return Err(format!("Unexpected output: {}", output)),
+        }
+
+        output.clear();
+    }
+}
+
+fn run_guessing_game(path: &PathBuf) -> Result<i64, String> {
+    let mut child = Command::new("cargo")
+        .current_dir(path)
+        .arg("run")
+        .arg("--quiet")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Unable to execute cargo run");
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .expect("Unable to get stdin from command");
+    let stdout = child
+        .stdout
+        .take()
+        .expect("Unable to get stdout from command");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("Unable to get stderr from command");
+
+    let mut reader = BufReader::new(stdout);
+    let mut err_reader = BufReader::new(stderr);
+    let result = play_guessing_game(&mut reader, &mut stdin);
+
+    child.kill().ok();
+    child
+        .wait()
+        .map_err(|err| format!("Unable to wait for child process: {}", err.to_string()))?;
+
+    let mut stderr_content = String::new();
+    err_reader
+        .read_to_string(&mut stderr_content)
+        .map_err(|err| format!("Unable to read stderr: {}", err.to_string()))?;
+
+    if !stderr_content.is_empty() {
+        return Err(format!("Unexpected content on stderr: {}", stderr_content));
+    }
+
+    result
+}
+
 impl Testable for Exercise06 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex06")
+    }
+
+    fn run_test(&self) -> TestResult {
+        if !self.check_clippy() {
+            eprintln!("`cargo clippy -- -D warnings` failed");
+
+            return TestResult::CompilationError;
+        }
+
+        if self.compile().is_err() {
+            eprintln!("Failed to compile");
+
+            return TestResult::CompilationError;
+        }
+
+        let mut results = HashSet::new();
+        for _ in 0..5 {
+            match run_guessing_game(&self.path()) {
+                Ok(number) => results.insert(number),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    return TestResult::Failed;
+                }
+            };
+        }
+
+        if results.len() == 1 {
+            eprintln!("Number doesn't seem to be random");
+            return TestResult::Failed;
+        }
+
+        TestResult::Passed
     }
 }

--- a/rust/tester/src/module00/exercise07/mod.rs
+++ b/rust/tester/src/module00/exercise07/mod.rs
@@ -9,4 +9,8 @@ impl Testable for Exercise07 {
     fn path(&self) -> path::PathBuf {
         repository_path().join("ex07")
     }
+
+    fn cargo_test_mod(&self) -> &'static str {
+        include_str!("./shortinette_tests.rs")
+    }
 }

--- a/rust/tester/src/module00/exercise07/shortinette_tests.rs
+++ b/rust/tester/src/module00/exercise07/shortinette_tests.rs
@@ -1,0 +1,289 @@
+#[cfg(test)]
+mod shortinette_tests_0007 {
+    use ex07::strpcmp;
+    use rand::{distributions::Alphanumeric, Rng};
+
+    fn random_u8_vec(size: usize) -> Vec<u8> {
+        let mut rng = rand::thread_rng();
+        (0..size).map(|_| rng.sample(Alphanumeric)).collect()
+    }
+
+    #[test]
+    fn equal_test() {
+        let random_input = random_u8_vec(32);
+        assert!(strpcmp(&random_input, &random_input));
+    }
+
+    #[test]
+    fn additional_wildcard_start() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.insert(0, b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn replace_wildcard_start() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input.clone();
+        with_wildcard[0] = b'*';
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn additional_multiple_wildcard_start() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.splice(0..0, std::iter::repeat(b'*').take(5));
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn one_wildcard_replace_multiple_start() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input[rng.gen_range(5..20)..].to_vec();
+        with_wildcard.insert(0, b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn additional_wildcard_end() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.push(b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn replace_wildcard_end() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input[..random_input.len() - 1].to_vec();
+        with_wildcard.push(b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn additional_multiple_wildcard_end() {
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.extend(std::iter::repeat(b'*').take(5));
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn one_wildcard_replace_multiple_end() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input[..rng.gen_range(10..25)].to_vec();
+        with_wildcard.push(b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn wildcard_middle_replace() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let position = rng.gen_range(1..random_input.len() - 1);
+
+        let mut with_wildcard = random_input.clone();
+        with_wildcard[position] = b'*';
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn wildcard_middle_additional() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let position = rng.gen_range(1..random_input.len() - 1);
+
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.insert(position, b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn additional_multiple_wildcard_middle() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let position = rng.gen_range(1..random_input.len() - 1);
+
+        let mut with_wildcard = random_input.clone();
+        with_wildcard.splice(position..position, std::iter::repeat(b'*').take(5));
+    }
+
+    #[test]
+    fn one_wildcard_replace_multiple_middle() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input[0..rng.gen_range(5..10)].to_vec();
+        with_wildcard.push(b'*');
+        with_wildcard.extend(&random_input[rng.gen_range(20..25)..]);
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn start_end_wildcard() {
+        let mut rng = rand::thread_rng();
+
+        let random_input = random_u8_vec(32);
+        let mut with_wildcard = random_input[rng.gen_range(5..10)..rng.gen_range(15..20)].to_vec();
+        with_wildcard.insert(0, b'*');
+        with_wildcard.push(b'*');
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn multiple_substrings() {
+        let part1 = random_u8_vec(8);
+        let part2 = random_u8_vec(8);
+
+        let random_input: Vec<u8> = part1
+            .iter()
+            .chain(std::iter::repeat(&part2).take(5).flat_map(|v| v))
+            .copied()
+            .collect();
+
+        let with_wildcard: Vec<u8> = part1.iter().chain(b"*").chain(&part2).copied().collect();
+
+        assert!(strpcmp(&random_input, &with_wildcard));
+    }
+
+    #[test]
+    fn empty_query_only_wildcards() {
+        let mut rng = rand::thread_rng();
+
+        let pattern: Vec<u8> = std::iter::repeat(b'*').take(rng.gen_range(5..10)).collect();
+        assert!(strpcmp(b"", &pattern));
+    }
+
+    #[test]
+    fn both_empty() {
+        assert!(strpcmp(b"", b""));
+    }
+
+    #[test]
+    fn wildcard_in_query_empty_pattern() {
+        let mut rng = rand::thread_rng();
+
+        let query: Vec<u8> = std::iter::repeat(b'*').take(rng.gen_range(5..10)).collect();
+        assert_eq!(strpcmp(&query, b""), false);
+    }
+
+    #[test]
+    fn start_mismatch() {
+        let random_input = random_u8_vec(32);
+        let with_wildcard: Vec<u8> = random_input[1..].iter().chain(b"*").copied().collect();
+
+        assert_eq!(strpcmp(&random_input, &with_wildcard), false);
+    }
+
+    #[test]
+    fn end_mismatch() {
+        let random_input = random_u8_vec(32);
+        let with_wildcard: Vec<u8> = [vec![b'*'], random_input[..31].to_vec()]
+            .iter()
+            .flat_map(|v| v)
+            .copied()
+            .collect();
+
+        assert_eq!(strpcmp(&random_input, &with_wildcard), false);
+    }
+
+    #[test]
+    fn same_amount_of_wildcards() {
+        let mut rng = rand::thread_rng();
+
+        let part1 = random_u8_vec(8);
+        let part2 = random_u8_vec(8);
+
+        let input: Vec<u8> = part1
+            .iter()
+            .chain(std::iter::repeat(&b'*').take(rng.gen_range(1..5)))
+            .chain(&part2)
+            .copied()
+            .collect();
+
+        assert!(strpcmp(&input, &input));
+    }
+
+    #[test]
+    fn more_wildcards_in_query() {
+        let mut rng = rand::thread_rng();
+
+        let part1 = random_u8_vec(8);
+        let part2 = random_u8_vec(8);
+        let wildcard_count = rng.gen_range(1..5);
+
+        let query: Vec<u8> = part1
+            .iter()
+            .chain(std::iter::repeat(&b'*').take(wildcard_count + 1))
+            .chain(&part2)
+            .copied()
+            .collect();
+
+        let pattern: Vec<u8> = part1
+            .iter()
+            .chain(std::iter::repeat(&b'*').take(wildcard_count))
+            .chain(&part2)
+            .copied()
+            .collect();
+
+        assert!(strpcmp(&query, &pattern));
+    }
+
+    #[test]
+    fn wildcard_wrong_side() {
+        let random_input = random_u8_vec(32);
+
+        let query: Vec<u8> = random_input.iter().chain(b"*").copied().collect();
+        let pattern: Vec<u8> = [b'*'].iter().chain(&random_input).copied().collect();
+
+        assert_eq!(strpcmp(&query, &pattern), false);
+    }
+
+    #[test]
+    fn wildcard_in_query_none_in_pattern() {
+        let part1 = random_u8_vec(8);
+        let part2 = random_u8_vec(8);
+
+        let query: Vec<u8> = part1.iter().chain(b"*").chain(&part2).copied().collect();
+        let pattern: Vec<u8> = part1.iter().chain(&part2).copied().collect();
+
+        assert_eq!(strpcmp(&query, &pattern), false);
+    }
+
+    #[test]
+    fn substring_without_wildcard_1() {
+        let random_input = random_u8_vec(32);
+
+        let pattern = random_input[..31].to_vec();
+        assert_eq!(strpcmp(&random_input, &pattern), false);
+    }
+
+    #[test]
+    fn substring_without_wildcard_2() {
+        let random_input = random_u8_vec(32);
+
+        let query = random_input[..31].to_vec();
+        assert_eq!(strpcmp(&query, &random_input), false);
+    }
+}

--- a/rust/tester/src/testable.rs
+++ b/rust/tester/src/testable.rs
@@ -71,6 +71,14 @@ pub trait Testable {
             .add_dependency("libc", "0.2.169")
             .expect("Failed to add libc as dependency to test project");
 
+        cargo
+            .add_dependency("chrono", "0.4")
+            .expect("Failed to add chrono as dependency to test project");
+
+        cargo
+            .add_dependency("similar-asserts", "1.6")
+            .expect("Failed to add similar-asserts as dependency to test project");
+
         let mut lib_file = fs::File::create(cargo.path().join("src/lib.rs"))
             .expect("Failed to open src/lib.rs of test module");
         lib_file


### PR DESCRIPTION
- Added tests for all exercises of module 00
- Changes in subjects:
  -  Added `pub` keyword to the functions
  - I added an additional function requirement to ex05 (Friday the 13th):
    ```rust
    pub fn friday_the_13th<W: std::io::Write>(writer: &mut W, year: u32);
    ```
    This way we can test it with different input for the year to prevent hard-coding of output, and I just specified that the main function should just print it until the end of year 2025. I also specified explicitly that all functions should panic when the `year` is 0, which was only the case for the `is_leap_year` function before.
- Added dependencies:
  - `chrono`, which is used by the tests for ex05 (this way I don't have to push the solution into the repo hehe)
  - `similar-asserts` produces a nice `diff` of the output if its not correct. Also used on ex05, so we don't print 10000 lines in the trace just because the last line is wrong
  - `toml` used on ex04 (Shipping with Cargo)